### PR TITLE
fix: added export for ConnectionState

### DIFF
--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -273,4 +273,5 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
   }
 }
 
+export { ConnectionState } from './connection-state-handler';
 export { MediaStreamTrackKind, RTCDataChannelOptions, PeerConnection };


### PR DESCRIPTION
Added export for ConnectionState that was missed in https://github.com/webex/webrtc-core/pull/8 