### PR TITLE
chore:  created custom track for audio and video

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './media/local-camera-track';
 export * from './media/local-display-track';
 export * from './media/local-microphone-track';
 export * from './media/local-track';
+export * from './media/local-video-track';
 export * from './peer-connection';
 export * from './peer-connection-utils';
 export { media };

--- a/src/media/local-audio-track.ts
+++ b/src/media/local-audio-track.ts
@@ -1,0 +1,40 @@
+import { LocalTrack } from './local-track';
+
+export type AudioDeviceConstraints = {
+  deviceId?: string;
+};
+
+export type StaticAudioEncoderConfig = {
+  low: '16kHz';
+};
+
+export type AudioEncoderConfig = {
+  bitrate?: number;
+  sampleRate?: number;
+  sampleSize?: number;
+  channelCount?: number;
+};
+
+export type MicrophoneConstraints = {
+  echoCancellation?: boolean;
+  autoGainControl?: boolean;
+  noiseSuppression?: boolean;
+  microphoneDeviceId?: string;
+  encoderConfig?: AudioEncoderConfig;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TrackEffect = any;
+/**
+ * Represents a audio track for a audio source.
+ */
+export class LocalAudioTrack extends LocalTrack {
+  /**
+   * Makes sure to apply the encoderConfig for the audio.
+   *
+   * @param encoderConfig - Encoder config for audio.
+   */
+  setEncoderConfig(encoderConfig: AudioEncoderConfig): void {
+    this.getMediaStreamTrack().applyConstraints(encoderConfig);
+  }
+}

--- a/src/media/local-camera-track.ts
+++ b/src/media/local-camera-track.ts
@@ -1,6 +1,6 @@
-import { LocalTrack } from './local-track';
+import { LocalVideoTrack } from './local-video-track';
 
 /**
  * Represents a local track for a camera source.
  */
-export class LocalCameraTrack extends LocalTrack {}
+export class LocalCameraTrack extends LocalVideoTrack {}

--- a/src/media/local-display-track.ts
+++ b/src/media/local-display-track.ts
@@ -1,6 +1,6 @@
-import { LocalTrack } from './local-track';
+import { LocalVideoTrack } from './local-video-track';
 
 /**
  * Represents a local track for a display source.
  */
-export class LocalDisplayTrack extends LocalTrack {}
+export class LocalDisplayTrack extends LocalVideoTrack {}

--- a/src/media/local-microphone-track.ts
+++ b/src/media/local-microphone-track.ts
@@ -1,6 +1,6 @@
-import { LocalTrack } from './local-track';
+import { LocalAudioTrack } from './local-audio-track';
 
 /**
  * Represents a local track for a microphone source.
  */
-export class LocalMicrophoneTrack extends LocalTrack {}
+export class LocalMicrophoneTrack extends LocalAudioTrack {}

--- a/src/media/local-track.ts
+++ b/src/media/local-track.ts
@@ -1,23 +1,8 @@
 /* eslint-disable no-underscore-dangle */
-import { EventEmitter, EventMap } from '../event-emitter';
+import { EventMap } from '../event-emitter';
 import { MediaStreamTrackKind } from '../peer-connection';
 import { logger } from '../util/logger';
-
-export enum LocalTrackEvents {
-  Ended = 'ended',
-  Muted = 'muted',
-  /**
-   * Fires when the published state of a LocalTrack changes.  A value of 'true' indicates the
-   * track has been published, and 'false' indicates that it is no longer published.  Tracks are
-   * unpublished by default, and must be published explicitly (no event will be fired to indicate
-   * the initial state of 'unpublished').
-   */
-  PublishedStateUpdate = 'published-state-update',
-  /**
-   * Fires when there has been a change in the underlying track.
-   */
-  UnderlyingTrackChange = 'underlying-track-change',
-}
+import { Events, Track } from './track';
 
 export interface TrackState {
   id: string;
@@ -39,11 +24,8 @@ export type TrackPublishEvent = {
   trackState: TrackState;
 };
 
-export interface TrackEvents extends EventMap {
-  [LocalTrackEvents.Ended]: (event: TrackEndEvent) => void;
-  [LocalTrackEvents.Muted]: (event: TrackMuteEvent) => void;
-  [LocalTrackEvents.PublishedStateUpdate]: (event: TrackPublishEvent) => void;
-  [LocalTrackEvents.UnderlyingTrackChange]: () => void;
+export interface LocalTrackEvents extends EventMap {
+  [Events.PublishedStateUpdate]: (event: TrackPublishEvent) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,190 +36,10 @@ export type TrackEffect = any;
 /**
  * Basic Track class. Wrapper for LocalTrack from 'webrtc-core'.
  */
-export abstract class LocalTrack extends EventEmitter<TrackEvents> {
-  static Events = LocalTrackEvents;
-
-  /**
-   * The MediaStream that represents the current 'output' of this track.
-   * If no effects have been added, this will be the original MediaStream;
-   * if effects have been added, this will represent the output of the 'last'
-   * effect in the pipeline.
-   */
-  private _underlyingStream!: MediaStream;
-
-  /**
-   * The MediaStream that was passed to the constructor.
-   */
-  private originalStream: MediaStream;
-
+export abstract class LocalTrack extends Track {
   private isPublished = false;
 
   private effects: Map<string, TrackEffect> = new Map();
-
-  label: string;
-
-  /**
-   * Constructor for the Track class. Creates an empty CoreLocalTrack or uses an existing one.
-   *
-   * @param stream - The MediaStream for this LocalTrack.
-   */
-  constructor(stream: MediaStream) {
-    super();
-    this.originalStream = stream;
-    this.underlyingStream = stream;
-    // Effects create a new label but we want to retain the original one.
-    this.label = this.underlyingStream.getTracks()[0].label;
-
-    /**
-     * Emit ended event when the underlying track ends.
-     */
-    this.underlyingTrack.onended = () => {
-      this.emit(LocalTrackEvents.Ended, { trackState: this.trackState });
-    };
-  }
-
-  /**
-   * Get the kind of this track.
-   * NOTE(brian): the need for this will likely go away once we get the rest of the track hierarchy
-   * done, as we can use something like instanceof instead.
-   *
-   * @returns - The kind of this track, as a MediaStreamTrackKind.
-   */
-  get kind(): MediaStreamTrackKind {
-    return this.underlyingTrack.kind as MediaStreamTrackKind;
-  }
-
-  /**
-   * Get id of this track.
-   *
-   * @returns The id of this track.
-   */
-  get id(): string {
-    return this.underlyingTrack.id;
-  }
-
-  /**
-   * Get muted state of this track.
-   *
-   * @returns The muted state of this track.
-   */
-  get muted(): boolean {
-    return !this.underlyingTrack.enabled;
-  }
-
-  /**
-   * Get published state of this track.
-   *
-   * @returns The published state of this track.
-   */
-  get published(): boolean {
-    return this.isPublished;
-  }
-
-  /**
-   * Get the underlying MediaStream.
-   *
-   * @returns The underlying MediaStream.
-   */
-  get underlyingStream(): MediaStream {
-    return this._underlyingStream;
-  }
-
-  /**
-   * Set the underlying MediaStream.
-   */
-  set underlyingStream(stream: MediaStream) {
-    this._underlyingStream = stream;
-  }
-
-  /**
-   * Get current state of this track.
-   *
-   * @returns Current state of this track.
-   */
-  get trackState(): TrackState {
-    return { id: this.id, label: this.label, type: this.kind, muted: this.muted };
-  }
-
-  /**
-   * Get the underlying MediaStreamTrack.
-   *
-   * @returns The underlying MediaStreamTrack.
-   */
-  get underlyingTrack(): MediaStreamTrack {
-    return this._underlyingStream.getTracks()[0];
-  }
-
-  /**
-   * Get the original MediaStreamTrack. We retain a reference to the stream obtained through
-   * `getUserMedia()` to ensure it's updated alongside the `underlyingStream`. These two streams may
-   * be different if effects have been added to the original stream.
-   *
-   * @returns The original MediaStreamTrack.
-   */
-  private get originalTrack(): MediaStreamTrack {
-    return this.originalStream.getTracks()[0];
-  }
-
-  /**
-   * Set the mute state of this track.
-   *
-   * @param muted - True to mute, false to unmute.
-   * @fires LocalTrackEvents.Muted
-   */
-  setMuted(muted: boolean): void {
-    // Only change state if it's different, where "enabled" means "unmuted."
-    if (this.underlyingTrack.enabled === muted) {
-      this.originalTrack.enabled = !muted;
-      this.underlyingTrack.enabled = !muted;
-      this.emit(LocalTrackEvents.Muted, { trackState: this.trackState });
-      logger.log(`Local track ${muted ? 'muted' : 'unmuted'}:`, { trackState: this.trackState });
-    }
-  }
-
-  /**
-   * Set the published state of this LocalTrack.
-   *
-   * @param isPublished - True if this track has been published, false otherwise.
-   * @fires LocalTrackEvents.PublishedStateUpdate
-   */
-  setPublished(isPublished: boolean): void {
-    if (this.isPublished !== isPublished) {
-      this.isPublished = isPublished;
-      this.emit(LocalTrackEvents.PublishedStateUpdate, {
-        trackState: this.trackState,
-        isPublished,
-      });
-      logger.log(`Local track ${isPublished ? 'published' : 'unpublished'}:`, {
-        trackState: this.trackState,
-      });
-    }
-  }
-
-  /**
-   * Stop this track.
-   *
-   * @fires LocalTrackEvents.Ended
-   */
-  stop(): void {
-    this.originalTrack.stop();
-    this.underlyingTrack.stop();
-    this.emit(LocalTrackEvents.Ended, { trackState: this.trackState });
-    logger.log(`Local track stopped:`, { trackState: this.trackState });
-  }
-
-  /**
-   * Adds an effect to a local track.
-   *
-   * @param name - The name of the effect.
-   * @param effect - The effect to add.
-   */
-  async addEffect(name: string, effect: TrackEffect): Promise<void> {
-    await effect.load(this.underlyingStream);
-    this.underlyingStream = effect.getUnderlyingStream();
-    this.effects.set(name, effect);
-    this.emit(LocalTrackEvents.UnderlyingTrackChange);
-  }
 
   /**
    * Get an effect by name.
@@ -256,9 +58,49 @@ export abstract class LocalTrack extends EventEmitter<TrackEvents> {
   }
 
   /**
-   * Cleanup local microphone track.
+   * Adds an effect to a local track.
+   *
+   * @param name - The name of the effect.
+   * @param effect - The effect to add.
+   */
+  async addEffect(name: string, effect: TrackEffect): Promise<void> {
+    await effect.load(new MediaStream([this.getMediaStreamTrack()]));
+    this.setMediaStreamTrackWithEffects(effect.getUnderlyingStream().getAudioTracks()[0]);
+    this.effects.set(name, effect);
+  }
+
+  /**
+   * disposes the effect already applied .
    */
   disposeEffects(): void {
     this.effects.forEach((effect: TrackEffect) => effect.dispose());
+  }
+
+  /**
+   * Get published state of this track.
+   *
+   * @returns The published state of this track.
+   */
+  get published(): boolean {
+    return this.isPublished;
+  }
+
+  /**
+   * Set the published state of this LocalTrack.
+   *
+   * @param isPublished - True if this track has been published, false otherwise.
+   * @fires LocalTrackEvents.PublishedStateUpdate
+   */
+  setPublished(isPublished: boolean): void {
+    if (this.isPublished !== isPublished) {
+      this.isPublished = isPublished;
+      this.emit(Events.PublishedStateUpdate, {
+        trackState: this.trackState,
+        isPublished,
+      });
+      logger.log(`Local track ${isPublished ? 'published' : 'unpublished'}:`, {
+        trackState: this.trackState,
+      });
+    }
   }
 }

--- a/src/media/local-video-track.ts
+++ b/src/media/local-video-track.ts
@@ -1,0 +1,72 @@
+import { LocalTrack } from './local-track';
+
+export enum FacingMode {
+  user = 'user',
+  environment = 'environment',
+}
+
+export enum OptimizationMode {
+  motion = 'motion',
+  detail = 'detail',
+}
+
+export type ConstrainLong = {
+  min?: number;
+  max?: number;
+  ideal?: number;
+  exact?: number;
+};
+
+export type VideoEncoderConfig = {
+  bitRateMin?: number;
+  bitrateMax?: number;
+  frameRate?: number | ConstrainLong;
+  height?: number | ConstrainLong;
+  width?: number | ConstrainLong;
+  aspectRatio?: number;
+};
+
+/**
+ * A class to map resolution with video constraints.
+ */
+export const StaticVideoEncoderConfig: { [key: string]: VideoEncoderConfig } = {
+  '1080p': { frameRate: 15, bitrateMax: 2080, width: 1920, height: 1080 },
+
+  '720p': { frameRate: 15, bitrateMax: 1130, width: 1280, height: 720 },
+
+  '480p': { frameRate: 15, bitrateMax: 500, width: 640, height: 480 },
+
+  '360p': { frameRate: 15, bitrateMax: 400, width: 640, height: 360 },
+
+  '240p': { frameRate: 15, bitrateMax: 200, width: 320, height: 240 },
+
+  '180p': { frameRate: 15, bitrateMax: 140, width: 320, height: 180 },
+
+  '120p': { frameRate: 15, bitrateMax: 65, width: 160, height: 120 },
+};
+
+export type VideoConstraints = {
+  cameraDeviceId?: string;
+  facingMode?: FacingMode;
+  optimizationMode?: OptimizationMode;
+  encoderConfig?: VideoEncoderConfig;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TrackEffect = any;
+// TBD: Fix this once types are published separately
+// export type TrackEffect = BaseMicrophoneEffect | BaseCameraEffect;
+
+/**
+ * Represents a local video track.
+ */
+export class LocalVideoTrack extends LocalTrack {
+  /**
+   * Applies the passed video constraints.
+   *
+   * @param encoderConfig - Custom encoder config for video.
+   */
+  setEncoderConfig(encoderConfig: VideoEncoderConfig): void {
+    this.getMediaStreamTrack().applyConstraints(encoderConfig);
+  }
+}


### PR DESCRIPTION
1) Splits the local-track into local-audio-track and local-video-track
2) remove the logic of saving streams as its not needed for effects , we could create a dynamic streams when starting effects 
3) keeping the tracks basics so that we can use it for remote tracks

NOTE: remote track will come later 