### PR TITLE
fix: restore the original stream on disposing effects

### DIFF
--- a/src/media/local-track.ts
+++ b/src/media/local-track.ts
@@ -260,5 +260,8 @@ export abstract class LocalTrack extends EventEmitter<TrackEvents> {
    */
   disposeEffects(): void {
     this.effects.forEach((effect: TrackEffect) => effect.dispose());
+
+    this.underlyingStream = this.originalStream;
+    this.emit(LocalTrackEvents.UnderlyingTrackChange);
   }
 }

--- a/src/media/local-track.ts
+++ b/src/media/local-track.ts
@@ -259,9 +259,12 @@ export abstract class LocalTrack extends EventEmitter<TrackEvents> {
    * Cleanup local microphone track.
    */
   disposeEffects(): void {
-    this.effects.forEach((effect: TrackEffect) => effect.dispose());
+    if (this.effects.size > 0) {
+      this.effects.forEach((effect: TrackEffect) => effect.dispose());
+      this.effects.clear();
 
-    this.underlyingStream = this.originalStream;
-    this.emit(LocalTrackEvents.UnderlyingTrackChange);
+      this.underlyingStream = this.originalStream;
+      this.emit(LocalTrackEvents.UnderlyingTrackChange);
+    }
   }
 }


### PR DESCRIPTION
When disposing all effects attached to a track, we need to restore the underlying stream to the original stream.