### PR TITLE
feat: add the api for fetching the connection type

### DIFF
--- a/src/mocks/rtc-peer-connection-stub.ts
+++ b/src/mocks/rtc-peer-connection-stub.ts
@@ -10,6 +10,9 @@ class RTCPeerConnectionStub {
   createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit> {
     return new Promise(() => {});
   }
+  getStats(): Promise<any> {
+    return new Promise(() => {});
+  }
   onconnectionstatechange: () => void = () => {};
   oniceconnectionstatechange: () => void = () => {};
 }

--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -33,6 +33,7 @@ interface PeerConnectionEventHandlers extends EventMap {
   [PeerConnectionEvents.ConnectionStateChange]: (state: ConnectionState) => void;
 }
 
+type ConnectionType = 'UDP' | 'TCP' | 'TURN-TLS' | 'TURN-TCP' | 'TURN-UDP' | 'unknown';
 /**
  * Manages a single RTCPeerConnection with the server.
  */
@@ -289,9 +290,9 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
   /**
    * Returns the type of a connection that has been established.
    *
-   * @returns The connection type which would be {Promise<'UDP' | 'TCP' | 'TURN-TLS' | 'TURN-TCP' | 'TURN-UDP' | 'unknown'>}.
+   * @returns The connection type which would be `ConnectionType`.
    */
-  async getCurrentConnectionType(): Promise<string> {
+  async getCurrentConnectionType(): Promise<ConnectionType> {
     // make sure this method only can be called when the ice connection is established;
     const isIceConnected =
       this.pc.iceConnectionState === 'connected' || this.pc.iceConnectionState === 'completed';
@@ -320,7 +321,7 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
       return 'unknown';
     }
     if (localCandidate.relayProtocol) {
-      return `TURN-${localCandidate.relayProtocol.toUpperCase()}`;
+      return `TURN-${localCandidate.relayProtocol.toUpperCase()}` as ConnectionType;
     }
     return localCandidate.protocol?.toUpperCase();
   }


### PR DESCRIPTION
API for fetching the the connection type, which would return the type of Promise<'UDP' | 'TCP' | 'TURN-TLS' | 'TURN-TCP' | 'TURN-UDP' | 'unknown'>. 
Details can refer to https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-379327