### PR TITLE
chore: Import media sdk from bundle

### DIFF
--- a/samples/src/App.js
+++ b/samples/src/App.js
@@ -11,7 +11,7 @@ import {
   getSpeakers,
   getMicrophones,
   getCameras,
-} from "@webex/webrtc-core";
+} from "./bundle";
 
 import {
   NoiseReductionEffect,


### PR DESCRIPTION
When I ran `yarn start` I found these three functions can not be found, think they are discarded due to rollup tree-shaking. In opposite, `bundle` includes all exported functions. It won't throw function not found error if we use `bundle`.
<img width="1541" alt="image" src="https://user-images.githubusercontent.com/15974131/215677967-51b0950f-5457-4b09-ab19-61a1ffd6c630.png">
