### PR TITLE
feat: support applying music mode constraints

### DIFF
--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -31,6 +31,9 @@ export class WcmeError {
 
 export type AudioDeviceConstraints = {
   deviceId?: string;
+  autoGainControl?: boolean;
+  echoCancellation?: boolean;
+  noiseSuppression?: boolean;
 };
 
 export type VideoDeviceConstraints = {

--- a/src/media/local-track.spec.ts
+++ b/src/media/local-track.spec.ts
@@ -51,4 +51,14 @@ describe('LocalTrack', () => {
 
     expect(emitted).toBe(true);
   });
+
+  it('should apply and get underlying track constraints', () => {
+    expect.assertions(1);
+
+    localTrack.applyConstraints({ autoGainControl: true });
+
+    const constraints = localTrack.getConstraints();
+
+    expect(constraints).toStrictEqual({ autoGainControl: true });
+  });
 });

--- a/src/media/local-track.ts
+++ b/src/media/local-track.ts
@@ -267,4 +267,33 @@ export abstract class LocalTrack extends EventEmitter<TrackEvents> {
       this.emit(LocalTrackEvents.UnderlyingTrackChange);
     }
   }
+
+  /**
+   * Apply constraints to the track.
+   *
+   * @param constraints - The constraints to apply to the track.
+   * @returns A promise which resolves when the constraints have been successfully applied.
+   */
+  async applyConstraints(constraints?: MediaTrackConstraints): Promise<void> {
+    logger.log(`Applying constraints to local track:`, constraints);
+    return this.underlyingTrack.applyConstraints(constraints);
+  }
+
+  /**
+   * Get the current constraints of the track.
+   *
+   * @returns The constraints of the track.
+   */
+  getConstraints(): MediaTrackConstraints {
+    return this.underlyingTrack.getConstraints();
+  }
+
+  /**
+   * Get the current settings of the track.
+   *
+   * @returns The settings of the track.
+   */
+  getSettings(): MediaTrackSettings {
+    return this.underlyingTrack.getSettings();
+  }
 }

--- a/src/mocks/media-stream-track-stub.ts
+++ b/src/mocks/media-stream-track-stub.ts
@@ -12,6 +12,8 @@ class MediaStreamTrackStub {
   // be fine.
   eventListeners: Map<string, any> = new Map();
 
+  constraints: MediaTrackConstraints = {};
+
   kind?: MediaStreamTrackKind;
 
   /**
@@ -23,6 +25,12 @@ class MediaStreamTrackStub {
    * Stop this track.
    */
   stop(): void {}
+
+  applyConstraints(constraints?: MediaTrackConstraints): void {}
+
+  getConstraints(): MediaTrackConstraints {
+    return {} as MediaTrackConstraints;
+  }
 
   getSettings(): MediaTrackSettings {
     return {} as MediaTrackSettings;

--- a/src/util/test-utils.ts
+++ b/src/util/test-utils.ts
@@ -30,6 +30,12 @@ export const createMockedStreamWithSize = (width: number, height: number): Media
     width,
     aspectRatio: width / height,
   });
+  track.applyConstraints.mockImplementation((constraints?: MediaTrackConstraints) => {
+    track.constraints = constraints || {};
+  });
+  track.getConstraints.mockImplementation(() => {
+    return track.constraints;
+  });
   mockStream.getVideoTracks.mockReturnValue([track as unknown as MediaStreamTrack]);
   mockStream.getTracks.mockReturnValue([track as unknown as MediaStreamTrack]);
   return mockStream as unknown as MediaStream;


### PR DESCRIPTION
This PR adds the necessary constraints and methods to support music mode on local audio tracks.

It adds the following APIs to LocalTrack:

- `applyConstraints`: useful for applying music mode constraints to the track, though [it doesn't work for audio constraints on Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=796964); still, I think it'll be useful for other browsers like Firefox, so that it doesn't need to make a new call to `getUserMedia`.
- `getConstraints`: not strictly necessary for music mode but useful for testing purposes.
- `getSettings`: as far as I know, this is the recommended way to get the device ID of the track, useful for calling `getUserMedia` again on Chrome.