### PR TITLE
feat: Method named getNumActiveSimulcastLayers & event to LocalTrack for constraints changed

### DIFF
--- a/src/media/local-track.spec.ts
+++ b/src/media/local-track.spec.ts
@@ -62,3 +62,24 @@ describe('LocalTrack', () => {
     expect(constraints).toStrictEqual({ autoGainControl: true });
   });
 });
+
+describe('LocalTrack getNumActiveSimulcastLayers', () => {
+  it('activeSimulcastLayers returns 3 if video height greater than 360', () => {
+    expect.hasAssertions();
+    const mockStream = createMockedStream(720);
+    const localTrack = new TestLocalTrack(mockStream);
+    expect(localTrack.getNumActiveSimulcastLayers()).toBe(3);
+  });
+  it('activeSimulcastLayers returns 2 if video height greater than 180 but less(equals) than 360', () => {
+    expect.hasAssertions();
+    const mockStream = createMockedStream(360);
+    const localTrack = new TestLocalTrack(mockStream);
+    expect(localTrack.getNumActiveSimulcastLayers()).toBe(2);
+  });
+  it('activeSimulcastLayers returns 1 if video height less(equals) than 180', () => {
+    expect.hasAssertions();
+    const mockStream = createMockedStream(180);
+    const localTrack = new TestLocalTrack(mockStream);
+    expect(localTrack.getNumActiveSimulcastLayers()).toBe(1);
+  });
+});

--- a/src/mocks/media-stream-track-stub.ts
+++ b/src/mocks/media-stream-track-stub.ts
@@ -26,7 +26,9 @@ class MediaStreamTrackStub {
    */
   stop(): void {}
 
-  applyConstraints(constraints?: MediaTrackConstraints): void {}
+  applyConstraints(constraints?: MediaTrackConstraints): Promise<void> {
+    return Promise.resolve();
+  }
 
   getConstraints(): MediaTrackConstraints {
     return {} as MediaTrackConstraints;

--- a/src/util/test-utils.ts
+++ b/src/util/test-utils.ts
@@ -33,6 +33,7 @@ export const createMockedStreamWithSize = (width: number, height: number): Media
   });
   track.applyConstraints.mockImplementation((constraints?: MediaTrackConstraints) => {
     track.constraints = constraints || {};
+    return Promise.resolve();
   });
   track.getConstraints.mockImplementation(() => {
     return track.constraints;

--- a/src/util/test-utils.ts
+++ b/src/util/test-utils.ts
@@ -8,11 +8,12 @@ jest.mock('../mocks/media-stream-track-stub');
 /**
  * Create a mocked stream with a mocked MediaStreamTrack.
  *
+ * @param videoHeight - Video height.
  * @returns A Mocked MediaStreamStub type coerced to a MediaStream.
  */
-export const createMockedStream = (): MediaStream => {
+export const createMockedStream = (videoHeight = 360): MediaStream => {
   // eslint-disable-next-line no-use-before-define
-  return createMockedStreamWithSize(640, 480);
+  return createMockedStreamWithSize((videoHeight * 16) / 9, videoHeight);
 };
 
 /**


### PR DESCRIPTION
This code changes merged the PR of Bryce's [support applying music mode constraints](https://github.com/webex/webrtc-core/pull/27/files)
Mainly changes: 
1.  Add an event to LocalTrack for when the constraints are called
2. Add a method named getNumActiveSimulcastLayers to check the resolution and return how many layers will be active