### PR TITLE
New style of events

### DIFF
--- a/src/connection-state-handler.spec.ts
+++ b/src/connection-state-handler.spec.ts
@@ -28,7 +28,7 @@ describe('ConnectionStateHandler', () => {
     expect.assertions(2);
     const connStateHandler = new ConnectionStateHandler(fakeCallback);
 
-    connStateHandler.on(ConnectionStateHandler.Events.ConnectionStateChanged, (state) => {
+    connStateHandler.Events.connectionStateChanged.on((state) => {
       expect(state).toStrictEqual(ConnectionState.Connecting);
     });
 
@@ -42,7 +42,7 @@ describe('ConnectionStateHandler', () => {
     expect.assertions(2);
     const connStateHandler = new ConnectionStateHandler(fakeCallback);
 
-    connStateHandler.on(ConnectionStateHandler.Events.ConnectionStateChanged, (state) => {
+    connStateHandler.Events.connectionStateChanged.on((state) => {
       expect(state).toStrictEqual(ConnectionState.Connecting);
     });
 

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,0 +1,68 @@
+/* eslint-disable max-classes-per-file */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { EventEmitter as EE } from 'events';
+import TypedEmitter, { EventMap } from 'typed-emitter';
+
+/**
+ *  Typed event emitter class.
+ */
+export class EventEmitter<T extends EventMap> extends (EE as {
+  new <TT extends EventMap>(): TypedEmitter<TT>;
+})<T> {}
+
+export { EventMap } from 'typed-emitter';
+
+type Handler = (...args: any[]) => void;
+
+/**
+ * A typed event class that can be used for subscription and emission of events.
+ */
+export class EventImpl<T extends Handler> {
+  private emitter = new EventEmitter<{
+    ['event']: T;
+  }>();
+
+  /**
+   * Add an event handler to be invoked when this event is emitted.
+   *
+   * @param handler - The handler to be invoked.
+   */
+  on(handler: T): void {
+    this.emitter.on('event', handler);
+  }
+
+  /**
+   * Add an event handler to be invoked the next time this event is emitted.
+   * This handler will be invoked at most once.
+   *
+   * @param handler - The handler to be invoked.
+   */
+  once(handler: T): void {
+    this.emitter.once('event', handler);
+  }
+
+  /**
+   * Remove the given handler.
+   *
+   * @param handler - The handler to remove.
+   */
+  off(handler: T): void {
+    this.emitter.off('event', handler);
+  }
+
+  /**
+   * Emit the event with the given arguments.
+   *
+   * @param args - The arguments to the event.
+   */
+  emit(...args: Parameters<T>): void {
+    this.emitter.emit('event', ...args);
+  }
+}
+
+/**
+ * A type which defines all methods of EventImpl that should be 'externally' accessible.
+ * Instances of EventImpl should be exposed as this type to external entities for.
+ */
+export type Event<T extends Handler> = Pick<EventImpl<T>, 'on' | 'once' | 'off'>;

--- a/src/event.ts
+++ b/src/event.ts
@@ -18,7 +18,7 @@ type Handler = (...args: any[]) => void;
 /**
  * A typed event class that can be used for subscription and emission of events.
  */
-export class EventImpl<T extends Handler> {
+export class TypedEventImpl<T extends Handler> {
   private emitter = new EventEmitter<{
     ['event']: T;
   }>();
@@ -65,4 +65,4 @@ export class EventImpl<T extends Handler> {
  * A type which defines all methods of EventImpl that should be 'externally' accessible.
  * Instances of EventImpl should be exposed as this type to external entities for.
  */
-export type Event<T extends Handler> = Pick<EventImpl<T>, 'on' | 'once' | 'off'>;
+export type TypedEvent<T extends Handler> = Pick<TypedEventImpl<T>, 'on' | 'once' | 'off'>;

--- a/src/peer-connection-utils.spec.ts
+++ b/src/peer-connection-utils.spec.ts
@@ -20,14 +20,16 @@ describe('getLocalDescriptionWithIceCandidates', () => {
     const promise = new PromiseHelper(
       getLocalDescriptionWithIceCandidates(mockPc as unknown as PeerConnection)
     );
-    expect(mockPc.on.mock.calls).toHaveLength(1);
-    expect(mockPc.on.mock.calls[0][0]).toBe(PeerConnection.Events.IceGatheringStateChange);
+    expect(mockPc.Events.iceGatheringStateChange.on.mock.calls).toHaveLength(1);
+    //expect(mockPc.on.mock.calls).toHaveLength(1);
+    //expect(mockPc.on.mock.calls[0][0]).toBe(PeerConnection.Events.IceGatheringStateChange);
     // Grab the listener that was installed
-    const iceGatheringStateListener = mockPc.on.mock.calls[0][1];
+    //const iceGatheringStateListener = mockPc.on.mock.calls[0][1];
+    const iceGatheringStateListener = mockPc.Events.iceGatheringStateChange.on.mock.calls[0][0];
     iceGatheringStateListener({
       target: {
         iceGatheringState: 'gathering',
-      },
+      } as unknown as EventTarget,
     });
     // The reason for these nested calls to Promise.resolve is because, unlike many tests around
     // Promises, here we're trying to validate that a promise _wasn't_ resolved when it shouldn't
@@ -41,7 +43,7 @@ describe('getLocalDescriptionWithIceCandidates', () => {
       iceGatheringStateListener({
         target: {
           iceGatheringState: 'complete',
-        },
+        } as unknown as EventTarget,
       });
       // Make sure the helper has had a chance to resolve its promise before we check again
       Promise.resolve().then(() => {
@@ -56,11 +58,12 @@ describe('getLocalDescriptionWithIceCandidates', () => {
   test('rejects if the local description is null', async () => {
     mockPc.getLocalDescription.mockReturnValueOnce(null);
     const promise = getLocalDescriptionWithIceCandidates(mockPc as unknown as PeerConnection);
-    const iceGatheringStateListener = mockPc.on.mock.calls[0][1];
+    //const iceGatheringStateListener = mockPc.on.mock.calls[0][1];
+    const iceGatheringStateListener = mockPc.Events.iceGatheringStateChange.on.mock.calls[0][0];
     iceGatheringStateListener({
       target: {
         iceGatheringState: 'complete',
-      },
+      } as unknown as EventTarget,
     });
     await expect(promise).rejects.toStrictEqual(expect.any(Error));
   });

--- a/src/peer-connection-utils.ts
+++ b/src/peer-connection-utils.ts
@@ -23,7 +23,7 @@ export function getLocalDescriptionWithIceCandidates(
         reject(new Error('Local description was null'));
       }
     };
-    peerConnection.on(PeerConnection.Events.IceGatheringStateChange, (e) => {
+    peerConnection.Events.iceGatheringStateChange.on((e) => {
       if ((e.target as RTCPeerConnection).iceGatheringState === 'complete') {
         getLocalDescAndResolve();
       }

--- a/src/peer-connection.spec.ts
+++ b/src/peer-connection.spec.ts
@@ -231,7 +231,7 @@ describe('PeerConnection', () => {
       expect.assertions(2);
       const connectionStateHandler = getInstantiatedConnectionStateHandler();
 
-      pc.on(PeerConnection.Events.ConnectionStateChange, (state) => {
+      pc.Events.connectionStateChange.on((state) => {
         expect(state).toStrictEqual(ConnectionState.Connecting);
       });
 

--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -62,12 +62,9 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
       };
     });
 
-    this.connectionStateHandler.on(
-      ConnectionStateHandler.Events.ConnectionStateChanged,
-      (state: ConnectionState) => {
-        this.emit(PeerConnection.Events.ConnectionStateChange, state);
-      }
-    );
+    this.connectionStateHandler.Events.connectionStateChanged.on((state: ConnectionState) => {
+      this.emit(PeerConnection.Events.ConnectionStateChange, state);
+    });
 
     // Forward the connection state related events to connection state handler
     // eslint-disable-next-line jsdoc/require-jsdoc


### PR DESCRIPTION
This PR introduces a new style of doing events that will be more event to classes in a hierarchy defining their own events at each layer.

I made many attempts at doing an "inhert-from-event-emitter" style approach, and couldn't get any of them to work consistently, so I gave this a try.  This PR defines a "typed event" and builds subscription and emission into the event itself, rather than the class.  There are a couple tradeoffs here:

Pros:
1. No fancy type-system metaprogramming.  While this does leverage EventEmitter under the covers, it doesn't expose any of the type weirdness to the classes itself, which is nice.
2. Plays nicely with inheritance.  These are just members, so we don't need to worry about getting the inheritance/APIs/access at each level correctly, these act just like normal members.
3. It gives classes the flexibility to decide who should be able to emit an event: everyone (internal and external), internal only (the class and its subclasses) or only the class itself.  This is controlled by the accessibility modifier on the event field (public, protected, or private).

Cons:
1. The syntax is unfamiliar compared to traditional event handler APIs, which usually exist on the class.  For example:

Traditional way: `myClass.on('SomeEvent', () => { ... });`
With this PR: `myClass.someEvent.on(() => { ... });`

2. Discoverability: usually a developer can type `someClass.on(` and get some auto-complete hints as to the available events.  Since there is no common `on` API at the class, this is gone.  I've tried to address this somewhat in this PR by grouping the event members under an `Events` field in the class, so you'd do: `someClass.Events.` and then get autocomplete hints as to all the events evident there.

Other notes:
* I also split up the event interfaces a bit: `TypedEventImpl` defines the "complete" interface (i.e. it defines both subscription management and emission APIs).  `TypedEvent` defines only the subscription management APIs, _not_ emission: the thinking being that external entities typically shouldn't be able to call `emit` for a class.
* There's a problem here with jest that I haven't fixed yet.  Currently we validate some subscription behaviors by validating that 'on' methods were called, but now that the calls are on members, not methods, of a class, there's some funkiness in jest that needs to be addressed.  I think it should be doable...I just got tired of fighting it right now :)