### PR TITLE
fix: made create*Track() functions generic

### DIFF
--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -26,7 +26,7 @@ describe('Device Management', () => {
     it('should call getUserMedia', async () => {
       expect.assertions(1);
 
-      await createMicrophoneTrack({ deviceId: 'test-device-id' });
+      await createMicrophoneTrack(LocalMicrophoneTrack, { deviceId: 'test-device-id' });
       expect(media.getUserMedia).toHaveBeenCalledWith({
         audio: {
           deviceId: 'test-device-id',
@@ -37,7 +37,9 @@ describe('Device Management', () => {
     it('should return a LocalMicrophoneTrack instance', async () => {
       expect.assertions(1);
 
-      const localMicrophoneTrack = await createMicrophoneTrack({ deviceId: 'test-device-id' });
+      const localMicrophoneTrack = await createMicrophoneTrack(LocalMicrophoneTrack, {
+        deviceId: 'test-device-id',
+      });
       expect(localMicrophoneTrack).toBeInstanceOf(LocalMicrophoneTrack);
     });
   });
@@ -51,7 +53,7 @@ describe('Device Management', () => {
     it('should call getUserMedia', async () => {
       expect.assertions(1);
 
-      await createCameraTrack({ deviceId: 'test-device-id' });
+      await createCameraTrack(LocalCameraTrack, { deviceId: 'test-device-id' });
       expect(media.getUserMedia).toHaveBeenCalledWith({
         video: {
           deviceId: 'test-device-id',
@@ -62,7 +64,7 @@ describe('Device Management', () => {
     it('should call getUserMedia with constraints', async () => {
       expect.assertions(1);
 
-      await createCameraTrack({
+      await createCameraTrack(LocalCameraTrack, {
         deviceId: 'test-device-id',
         aspectRatio: 1.777,
         width: 1920,
@@ -85,7 +87,9 @@ describe('Device Management', () => {
     it('should return a LocalCameraTrack instance', async () => {
       expect.assertions(1);
 
-      const localCameraTrack = await createCameraTrack({ deviceId: 'test-device-id' });
+      const localCameraTrack = await createCameraTrack(LocalCameraTrack, {
+        deviceId: 'test-device-id',
+      });
       expect(localCameraTrack).toBeInstanceOf(LocalCameraTrack);
     });
   });
@@ -99,14 +103,14 @@ describe('Device Management', () => {
     it('should call getDisplayMedia', async () => {
       expect.assertions(1);
 
-      await createDisplayTrack();
+      await createDisplayTrack(LocalDisplayTrack);
       expect(media.getDisplayMedia).toHaveBeenCalledWith({ video: true });
     });
 
     it('should return a LocalDisplayTrack instance', async () => {
       expect.assertions(1);
 
-      const localDisplayTrack = await createDisplayTrack();
+      const localDisplayTrack = await createDisplayTrack(LocalDisplayTrack);
       expect(localDisplayTrack).toBeInstanceOf(LocalDisplayTrack);
     });
   });

--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -1,13 +1,14 @@
 import * as media from '../media';
-import { LocalCameraTrack } from '../media/local-camera-track';
-import { LocalDisplayTrack } from '../media/local-display-track';
-import { LocalMicrophoneTrack } from '../media/local-microphone-track';
+import { LocalTrack } from '../media/local-track';
 
 export enum ErrorTypes {
   DEVICE_PERMISSION_DENIED = 'DEVICE_PERMISSION_DENIED',
   CREATE_CAMERA_TRACK_FAILED = 'CREATE_CAMERA_TRACK_FAILED',
   CREATE_MICROPHONE_TRACK_FAILED = 'CREATE_MICROPHONE_TRACK_FAILED',
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T> = new (...args: any[]) => T;
 
 /**
  * Represents a WCME error, which contains error type and error message.
@@ -51,12 +52,14 @@ export type VideoDeviceConstraints = {
  * 1. Previous captured video track from the same device is not stopped .
  * 2. Previous createCameraTrack() call for the same device is in progress.
  *
+ * @param constructor - Constructor for the local camera track.
  * @param constraints - Video device constraints.
  * @returns A LocalTrack object or an error.
  */
-export async function createCameraTrack(
+export async function createCameraTrack<T extends LocalTrack>(
+  constructor: Constructor<T>,
   constraints?: VideoDeviceConstraints
-): Promise<LocalCameraTrack> {
+): Promise<T> {
   let stream: MediaStream;
   try {
     stream = await media.getUserMedia({ video: { ...constraints } });
@@ -66,18 +69,20 @@ export async function createCameraTrack(
       `Failed to create camera track ${error}`
     );
   }
-  return new LocalCameraTrack(stream);
+  return new constructor(stream);
 }
 
 /**
  * Creates a microphone audio track.
  *
+ * @param constructor - Constructor for the local microphone track.
  * @param constraints - Audio device constraints.
  * @returns A LocalTrack object or an error.
  */
-export async function createMicrophoneTrack(
+export async function createMicrophoneTrack<T extends LocalTrack>(
+  constructor: Constructor<T>,
   constraints?: AudioDeviceConstraints
-): Promise<LocalMicrophoneTrack> {
+): Promise<T> {
   let stream: MediaStream;
   try {
     stream = await media.getUserMedia({ audio: { ...constraints } });
@@ -87,17 +92,20 @@ export async function createMicrophoneTrack(
       `Failed to create microphone track ${error}`
     );
   }
-  return new LocalMicrophoneTrack(stream);
+  return new constructor(stream);
 }
 
 /**
  * Creates a display video track.
  *
+ * @param constructor - Constructor for the local display track.
  * @returns A Promise that resolves to a LocalDisplayTrack.
  */
-export async function createDisplayTrack(): Promise<LocalDisplayTrack> {
+export async function createDisplayTrack<T extends LocalTrack>(
+  constructor: Constructor<T>
+): Promise<T> {
   const stream = await media.getDisplayMedia({ video: true });
-  return new LocalDisplayTrack(stream);
+  return new constructor(stream);
 }
 
 /**


### PR DESCRIPTION
To allow JS-SDK to have classes that extend webrtc-core LocalMicrophoneTrack, LocalCameraTrack etc.