### PR TITLE
fix: incorrect log

### DIFF
--- a/src/connection-state-handler.ts
+++ b/src/connection-state-handler.ts
@@ -101,7 +101,7 @@ export class ConnectionStateHandler extends EventEmitter<ConnectionStateEventHan
     }
 
     logger.log(
-      `iceConnectionState=${iceState} connectionState=${connectionState} => ${this.mediaConnectionState}`
+      `iceConnectionState=${iceState} connectionState=${connectionState} => ${mediaConnectionState}`
     );
 
     return mediaConnectionState;


### PR DESCRIPTION
noticed this when debugging something else.  it results in very confusing log messages like:

```
[webrtc-core] iceConnectionState=connected connectionState=connected => Connecting
```

think it was just a typo.