### PR TITLE
fix: connectionState connecting could be usable

### DIFF
--- a/src/connection-state-handler.ts
+++ b/src/connection-state-handler.ts
@@ -94,7 +94,10 @@ export class ConnectionStateHandler extends EventEmitter<ConnectionStateEventHan
       mediaConnectionState = ConnectionState.Failed;
     } else if (connectionStates.some((value) => value === 'disconnected')) {
       mediaConnectionState = ConnectionState.Disconnected;
-    } else if (connectionStates.every((value) => value === 'connected' || value === 'completed')) {
+    } else if (
+      (iceState === 'connected' || iceState === 'completed') &&
+      (connectionState === 'connected' || connectionState === 'connecting')
+    ) {
       mediaConnectionState = ConnectionState.Connected;
     } else {
       mediaConnectionState = ConnectionState.Connecting;


### PR DESCRIPTION
This `connectionState` essentially represents the aggregate state of `iceConnectionState` of all ICE transports or RTCDtlsTransport being used by the connection. 

[RTCPeerConnection.connectionState](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionState) `connecting`:
> One or more of the ICE transports are currently in the process of establishing a connection; that is, their iceConnectionState is either checking or connected, and no transports are in the failed state.

[RTCPeerConnection.iceConnectionState](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState) `connected`:
> A usable pairing of local and remote candidates has been found for all components of the connection, and the connection has been established. It is possible that gathering is still underway, and it is also possible that the ICE agent is still checking candidates against one another looking for a better connection to use.

When `connectionState` is `connecting` and `iceConnectionState` is `connected`, it means at least a usable pairing of local and remote candidates has been found for all components of the connection, and the connection has been established. Meanwhile another candidate checking is still underway. We should handle this case as connected and usable.