### PR TITLE
feat: listen to track events and additional updates to stream classes

### DIFF
--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -129,6 +129,11 @@ describe('Device Management', () => {
       .spyOn(media, 'getDisplayMedia')
       .mockReturnValue(Promise.resolve(mockStream as unknown as MediaStream));
 
+    // This mock implementation is needed because createDisplayStreamWithAudio will create a new
+    // MediaStream from the video track of the mocked stream, so we need to make sure this new
+    // stream can get the mocked stream's track as well.
+    jest.spyOn(MediaStream.prototype, 'getTracks').mockImplementation(() => mockStream.getTracks());
+
     it('should call getDisplayMedia with audio', async () => {
       expect.assertions(1);
 
@@ -159,13 +164,6 @@ describe('Device Management', () => {
 
     it('should preserve the content hint', async () => {
       expect.assertions(1);
-
-      // This mock implementation is needed because createDisplayStreamWithAudio will create a new
-      // MediaStream from the video track of the mocked stream, so we need to make sure this new
-      // stream can get the mocked stream's track as well.
-      jest
-        .spyOn(MediaStream.prototype, 'getTracks')
-        .mockImplementation(() => mockStream.getTracks());
 
       const [localDisplayStream] = await createDisplayStreamWithAudio('motion');
       expect(localDisplayStream.contentHint).toBe('motion');

--- a/src/media/local-stream.spec.ts
+++ b/src/media/local-stream.spec.ts
@@ -1,25 +1,8 @@
 import { BaseEffect } from '@webex/web-media-effects';
-import MediaStreamStub from '../mocks/media-stream-stub';
 import MediaStreamTrackStub from '../mocks/media-stream-track-stub';
 import { mocked } from '../mocks/mock';
 import { createMockedStream } from '../util/test-utils';
 import { LocalStream } from './local-stream';
-
-/**
- * Create a mocked track effect.
- *
- * @returns A mocked TrackEvent.
- */
-const createMockedTrackEffect = () => {
-  const effectTrack = mocked(new MediaStreamTrackStub());
-  const effect = {
-    dispose: jest.fn().mockResolvedValue(undefined),
-    load: jest.fn().mockResolvedValue(effectTrack),
-    on: jest.fn(),
-  };
-
-  return { effectTrack, effect };
-};
 
 /**
  * A dummy LocalStream implementation so we can instantiate it for testing.
@@ -34,7 +17,7 @@ describe('LocalStream', () => {
   });
 
   describe('setMuted', () => {
-    it('should change the output track state based on being muted & unmuted', () => {
+    it('should change the input track state based on being muted & unmuted', () => {
       expect.assertions(2);
       // Simulate the default state of the track's enabled state.
       mockStream.getTracks()[0].enabled = true;
@@ -47,7 +30,7 @@ describe('LocalStream', () => {
   });
 
   describe('getSettings', () => {
-    it('should get the settings of the output track', () => {
+    it('should get the settings of the input track', () => {
       expect.assertions(1);
 
       const settings = localStream.getSettings();
@@ -56,7 +39,7 @@ describe('LocalStream', () => {
   });
 
   describe('stop', () => {
-    it('should call the stop method of the output track', () => {
+    it('should call the stop method of the input track', () => {
       expect.assertions(1);
 
       const spy = jest.spyOn(mockStream.getTracks()[0], 'stop');
@@ -65,57 +48,67 @@ describe('LocalStream', () => {
       expect(spy).toHaveBeenCalledWith();
     });
   });
-});
 
-describe('LocalTrack addEffect', () => {
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  const setup = () => {
-    const mockedStream = mocked(new MediaStreamStub());
-    const localStream = new TestLocalStream(mockedStream as unknown as MediaStream);
-    const { effectTrack, effect } = createMockedTrackEffect();
-    return { mockedStream, localStream, effectTrack, effect };
-  };
+  describe('addEffect', () => {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    const createMockedTrackEffect = () => {
+      const effectTrack = mocked(new MediaStreamTrackStub());
+      const effect = {
+        dispose: jest.fn().mockResolvedValue(undefined),
+        load: jest.fn().mockResolvedValue(effectTrack),
+        on: jest.fn(),
+      };
 
-  it('loads and uses the effect when there is no loading effect', async () => {
-    expect.hasAssertions();
+      return { effectTrack, effect };
+    };
 
-    const { localStream, effectTrack, effect } = setup();
+    it('loads and uses the effect when there is no loading effect', async () => {
+      expect.hasAssertions();
 
-    const addEffectPromise = localStream.addEffect('test-effect', effect as unknown as BaseEffect);
+      const { effectTrack, effect } = createMockedTrackEffect();
 
-    await expect(addEffectPromise).resolves.toBeUndefined();
-    expect(localStream.outputStream.getTracks()[0]).toBe(effectTrack);
-  });
+      const addEffectPromise = localStream.addEffect(
+        'test-effect',
+        effect as unknown as BaseEffect
+      );
 
-  it('does not use the effect when the loading effect is cleared during load', async () => {
-    expect.hasAssertions();
+      await expect(addEffectPromise).resolves.toBeUndefined();
+      expect(localStream.outputStream.getTracks()[0].id).toBe(effectTrack.id);
+    });
 
-    const { localStream, mockedStream, effect } = setup();
+    it('does not use the effect when the loading effect is cleared during load', async () => {
+      expect.hasAssertions();
 
-    // Add effect and immediately dispose all effects to clear loading effects
-    const addEffectPromise = localStream.addEffect('test-effect', effect as unknown as BaseEffect);
-    await localStream.disposeEffects();
+      const { effect } = createMockedTrackEffect();
 
-    await expect(addEffectPromise).rejects.toThrow('not required after loading');
-    expect(localStream.outputStream).toBe(mockedStream);
-  });
+      // Add effect and immediately dispose all effects to clear loading effects
+      const addEffectPromise = localStream.addEffect(
+        'test-effect',
+        effect as unknown as BaseEffect
+      );
+      await localStream.disposeEffects();
 
-  it('loads and uses the latest effect when the loading effect changes during load', async () => {
-    expect.hasAssertions();
-    const { effect: firstEffect } = createMockedTrackEffect();
-    const { localStream, effectTrack, effect: secondEffect } = setup();
+      await expect(addEffectPromise).rejects.toThrow('not required after loading');
+      expect(localStream.outputStream).toBe(mockStream);
+    });
 
-    const firstAddEffectPromise = localStream.addEffect(
-      'test-effect',
-      firstEffect as unknown as BaseEffect
-    );
-    const secondAddEffectPromise = localStream.addEffect(
-      'test-effect',
-      secondEffect as unknown as BaseEffect
-    );
-    await expect(firstAddEffectPromise).rejects.toThrow('not required after loading');
-    await expect(secondAddEffectPromise).resolves.toBeUndefined();
+    it('loads and uses the latest effect when the loading effect changes during load', async () => {
+      expect.hasAssertions();
+      const { effect: firstEffect } = createMockedTrackEffect();
+      const { effectTrack, effect: secondEffect } = createMockedTrackEffect();
 
-    expect(localStream.outputStream.getTracks()[0]).toBe(effectTrack);
+      const firstAddEffectPromise = localStream.addEffect(
+        'test-effect',
+        firstEffect as unknown as BaseEffect
+      );
+      const secondAddEffectPromise = localStream.addEffect(
+        'test-effect',
+        secondEffect as unknown as BaseEffect
+      );
+      await expect(firstAddEffectPromise).rejects.toThrow('not required after loading');
+      await expect(secondAddEffectPromise).resolves.toBeUndefined();
+
+      expect(localStream.outputStream.getTracks()[0].id).toBe(effectTrack.id);
+    });
   });
 });

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -99,7 +99,9 @@ abstract class _LocalStream extends Stream {
    */
   private changeOutputTrack(newTrack: MediaStreamTrack): void {
     if (this.outputTrack.id !== newTrack.id) {
-      // input track is same as old output track, so separate the input stream into a new stream
+      // If the input track and the *old* output track are currently the same, then the streams must
+      // be the same too. We want to apply the new track to the output stream without affecting the
+      // input stream, so we separate them by setting the input stream to be its own stream.
       if (this.inputTrack.id === this.outputTrack.id) {
         this.inputStream = new MediaStream(this.inputStream);
       }
@@ -107,7 +109,8 @@ abstract class _LocalStream extends Stream {
       this.outputStream.removeTrack(this.outputTrack);
       this.outputStream.addTrack(newTrack);
 
-      // input track is same as new output track, so set the streams to be the same
+      // If the input track and the *new* output track are now the same, then we want the streams to
+      // be the same too.
       if (this.inputTrack.id === this.outputTrack.id) {
         this.inputStream = this.outputStream;
       }

--- a/src/media/remote-stream.spec.ts
+++ b/src/media/remote-stream.spec.ts
@@ -8,6 +8,15 @@ describe('RemoteStream', () => {
     remoteStream = new RemoteStream(mockStream);
   });
 
+  describe('getSettings', () => {
+    it('should get the settings of the output track', () => {
+      expect.assertions(1);
+
+      const settings = remoteStream.getSettings();
+      expect(settings).toBe(mockStream.getTracks()[0].getSettings());
+    });
+  });
+
   describe('replaceTrack', () => {
     it('should call the removeTrack and addTrack methods of the output track', () => {
       expect.assertions(2);
@@ -20,6 +29,17 @@ describe('RemoteStream', () => {
 
       expect(removeTrackSpy).toHaveBeenCalledWith(mockStream.getTracks()[0]);
       expect(addTrackSpy).toHaveBeenCalledWith(newTrack);
+    });
+  });
+
+  describe('stop', () => {
+    it('should call the stop method of the output track', () => {
+      expect.assertions(1);
+
+      const spy = jest.spyOn(mockStream.getTracks()[0], 'stop');
+
+      remoteStream.stop();
+      expect(spy).toHaveBeenCalledWith();
     });
   });
 });

--- a/src/media/remote-stream.ts
+++ b/src/media/remote-stream.ts
@@ -5,60 +5,17 @@ import { Stream, StreamEventNames } from './stream';
  */
 export class RemoteStream extends Stream {
   /**
-   * Create a RemoteStream from the given values.
-   *
-   * @param stream - The output MediaStream for this Stream.
+   * @inheritdoc
    */
-  constructor(stream: MediaStream) {
-    super(stream);
-    this._outputStream = stream;
-
-    this.handleTrackMuted = this.handleTrackMuted.bind(this);
-    this.handleTrackUnmuted = this.handleTrackUnmuted.bind(this);
-
-    const outputTrack = this._outputStream.getTracks()[0];
-    this.addTrackHandlers(outputTrack);
-  }
-
-  /**
-   * Handler which is called when a track's mute event fires.
-   */
-  private handleTrackMuted() {
-    this[StreamEventNames.MuteStateChange].emit(true);
-  }
-
-  /**
-   * Handler which is called when a track's unmute event fires.
-   */
-  private handleTrackUnmuted() {
-    this[StreamEventNames.MuteStateChange].emit(false);
-  }
-
-  /**
-   * Add event handlers to a MediaStreamTrack.
-   *
-   * @param track - The MediaStreamTrack.
-   */
-  private addTrackHandlers(track: MediaStreamTrack) {
-    track.addEventListener('mute', this.handleTrackMuted);
-    track.addEventListener('unmute', this.handleTrackUnmuted);
-  }
-
-  /**
-   * Remove event handlers from a MediaStreamTrack.
-   *
-   * @param track - The MediaStreamTrack.
-   */
-  private removeTrackHandlers(track: MediaStreamTrack) {
-    track.removeEventListener('mute', this.handleTrackMuted);
-    track.removeEventListener('unmute', this.handleTrackUnmuted);
+  get muted(): boolean {
+    return !this.outputTrack.enabled;
   }
 
   /**
    * @inheritdoc
    */
-  get muted(): boolean {
-    return !this._outputStream.getTracks()[0].enabled;
+  getSettings(): MediaTrackSettings {
+    return this.outputTrack.getSettings();
   }
 
   /**
@@ -67,11 +24,24 @@ export class RemoteStream extends Stream {
    * @param newTrack - The track to add to the stream.
    */
   replaceTrack(newTrack: MediaStreamTrack): void {
-    const oldTrack = this._outputStream.getTracks()[0];
+    const oldTrack = this.outputTrack;
     this.removeTrackHandlers(oldTrack);
     this.outputStream.removeTrack(oldTrack);
 
     this.outputStream.addTrack(newTrack);
     this.addTrackHandlers(newTrack);
+
+    // TODO: Chrome/React may not automatically refresh the media element with the new track when
+    // the output track has changed, so we may need to emit an event here if this is the case.
+    // this[StreamEventNames.OutputTrackChange].emit(newTrack);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  stop(): void {
+    this.outputTrack.stop();
+    // calling stop() will not automatically emit Ended, so we emit it here
+    this[StreamEventNames.Ended].emit();
   }
 }

--- a/src/media/stream.ts
+++ b/src/media/stream.ts
@@ -16,7 +16,7 @@ interface StreamEvents {
 abstract class _Stream {
   protected _outputStream: MediaStream;
 
-  // TODO: this should be protected, but we need the helper type in ts-events
+  // TODO: these should be protected, but we need the helper type in ts-events
   // to hide the 'emit' method from TypedEvent.
   [StreamEventNames.MuteStateChange] = new TypedEvent<(muted: boolean) => void>();
 
@@ -29,6 +29,53 @@ abstract class _Stream {
    */
   constructor(stream: MediaStream) {
     this._outputStream = stream;
+    this.handleTrackMuted = this.handleTrackMuted.bind(this);
+    this.handleTrackUnmuted = this.handleTrackUnmuted.bind(this);
+    this.handleTrackEnded = this.handleTrackEnded.bind(this);
+    this.addTrackHandlers(this.outputTrack);
+  }
+
+  /**
+   * Handler which is called when a track's mute event fires.
+   */
+  private handleTrackMuted() {
+    this[StreamEventNames.MuteStateChange].emit(true);
+  }
+
+  /**
+   * Handler which is called when a track's unmute event fires.
+   */
+  private handleTrackUnmuted() {
+    this[StreamEventNames.MuteStateChange].emit(false);
+  }
+
+  /**
+   * Handler which is called when a track's ended event fires.
+   */
+  private handleTrackEnded() {
+    this[StreamEventNames.Ended].emit();
+  }
+
+  /**
+   * Add event handlers to a MediaStreamTrack.
+   *
+   * @param track - The MediaStreamTrack.
+   */
+  protected addTrackHandlers(track: MediaStreamTrack) {
+    track.addEventListener('mute', this.handleTrackMuted);
+    track.addEventListener('unmute', this.handleTrackUnmuted);
+    track.addEventListener('ended', this.handleTrackEnded);
+  }
+
+  /**
+   * Remove event handlers from a MediaStreamTrack.
+   *
+   * @param track - The MediaStreamTrack.
+   */
+  protected removeTrackHandlers(track: MediaStreamTrack) {
+    track.removeEventListener('mute', this.handleTrackMuted);
+    track.removeEventListener('unmute', this.handleTrackUnmuted);
+    track.removeEventListener('ended', this.handleTrackEnded);
   }
 
   /**
@@ -46,6 +93,27 @@ abstract class _Stream {
   get outputStream(): MediaStream {
     return this._outputStream;
   }
+
+  /**
+   * Get the track of the output stream.
+   *
+   * @returns The output track.
+   */
+  protected get outputTrack(): MediaStreamTrack {
+    return this.outputStream.getTracks()[0];
+  }
+
+  /**
+   * Get the settings of this stream.
+   *
+   * @returns The settings.
+   */
+  abstract getSettings(): MediaTrackSettings;
+
+  /**
+   * Stop this stream.
+   */
+  abstract stop(): void;
 }
 
 export const Stream = AddEvents<typeof _Stream, StreamEvents>(_Stream);

--- a/src/media/stream.ts
+++ b/src/media/stream.ts
@@ -14,7 +14,8 @@ interface StreamEvents {
  * Base stream class.
  */
 abstract class _Stream {
-  protected _outputStream: MediaStream;
+  // The output stream should never be reassigned, since it is the stream that is being given out.
+  readonly outputStream: MediaStream;
 
   // TODO: these should be protected, but we need the helper type in ts-events
   // to hide the 'emit' method from TypedEvent.
@@ -28,7 +29,7 @@ abstract class _Stream {
    * @param stream - The initial output MediaStream for this Stream.
    */
   constructor(stream: MediaStream) {
-    this._outputStream = stream;
+    this.outputStream = stream;
     this.handleTrackMuted = this.handleTrackMuted.bind(this);
     this.handleTrackUnmuted = this.handleTrackUnmuted.bind(this);
     this.handleTrackEnded = this.handleTrackEnded.bind(this);
@@ -84,15 +85,6 @@ abstract class _Stream {
    * @returns True if the stream is muted, false otherwise.
    */
   abstract get muted(): boolean;
-
-  /**
-   * Get the output stream.
-   *
-   * @returns The output stream.
-   */
-  get outputStream(): MediaStream {
-    return this._outputStream;
-  }
 
   /**
    * Get the track of the output stream.

--- a/src/mocks/media-stream-stub.ts
+++ b/src/mocks/media-stream-stub.ts
@@ -7,8 +7,12 @@ import './media-stream-track-stub';
 class MediaStreamStub {
   private tracks: MediaStreamTrack[];
 
-  constructor(tracks: MediaStreamTrack[] = []) {
-    this.tracks = tracks;
+  constructor(streamOrTracks?: MediaStream | MediaStreamTrack[]) {
+    if (streamOrTracks instanceof MediaStream) {
+      this.tracks = streamOrTracks.getTracks();
+    } else {
+      this.tracks = streamOrTracks || [];
+    }
   }
 
   addTrack(track: MediaStreamTrack) {

--- a/src/mocks/media-stream-track-stub.ts
+++ b/src/mocks/media-stream-track-stub.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { randomUUID } from 'crypto';
 import { MediaStreamTrackKind } from '../peer-connection';
 
 /**
@@ -15,6 +16,8 @@ class MediaStreamTrackStub {
   constraints: MediaTrackConstraints = {};
 
   kind?: MediaStreamTrackKind;
+
+  id = randomUUID();
 
   /**
    * Callback call onmute.


### PR DESCRIPTION
This PR makes several additional changes to the stream classes, including listening to media stream track events in `Stream`, adding more abstract methods, and updating how `inputTrack` and `outputTrack` are used in `LocalStream`.