### PR TITLE
fix: throw error in setLocalDescription if media line is missing codecs

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   },
   "dependencies": {
     "@webex/ts-events": "^1.1.0",
+    "@webex/web-capabilities": "^1.0.0",
     "@webex/web-media-effects": "^2.7.0",
     "events": "^3.3.0",
     "js-logger": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@webex/ts-events": "^1.1.0",
-    "@webex/web-capabilities": "^1.0.0",
+    "@webex/web-capabilities": "^1.1.0",
     "@webex/web-media-effects": "^2.7.0",
     "events": "^3.3.0",
     "js-logger": "^1.6.1",

--- a/src/mocks/rtc-peer-connection-stub.ts
+++ b/src/mocks/rtc-peer-connection-stub.ts
@@ -13,6 +13,9 @@ class RTCPeerConnectionStub {
   getStats(): Promise<any> {
     return new Promise(() => {});
   }
+  setLocalDescription(): Promise<any> {
+    return new Promise(() => {});
+  }
   onconnectionstatechange: () => void = () => {};
   oniceconnectionstatechange: () => void = () => {};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,6 +2685,11 @@
     events "^3.3.0"
     typed-emitter "^2.1.0"
 
+"@webex/web-capabilities@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@webex/web-capabilities/-/web-capabilities-1.0.0.tgz#b69f3ba492669431a486f79053146948af582de5"
+  integrity sha512-EIejiH9kdvpp2Cm0nq6DSusZMsiqNfJCbtmS0aiLAXPcC9gTcr7zDhqamnrbIc1PPsK08cJG7f2QDkH6BfFaPg==
+
 "@webex/web-media-effects@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@webex/web-media-effects/-/web-media-effects-2.7.0.tgz#f203f9512fb95d0639c74c10f39eda2e58663739"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,10 +2685,12 @@
     events "^3.3.0"
     typed-emitter "^2.1.0"
 
-"@webex/web-capabilities@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@webex/web-capabilities/-/web-capabilities-1.0.0.tgz#b69f3ba492669431a486f79053146948af582de5"
-  integrity sha512-EIejiH9kdvpp2Cm0nq6DSusZMsiqNfJCbtmS0aiLAXPcC9gTcr7zDhqamnrbIc1PPsK08cJG7f2QDkH6BfFaPg==
+"@webex/web-capabilities@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@webex/web-capabilities/-/web-capabilities-1.1.0.tgz#7e0e7c8b67ee9cb6b795fecf099ff748ef7d13c6"
+  integrity sha512-Sh++KBHhy8VmEQZtSFuKrvq82SgEILNkAfWvoJGWpCpV9+VirEpUdCYxwBv03V+DF2EcxmOcRt/n8bzjIG1b/A==
+  dependencies:
+    bowser "^2.11.0"
 
 "@webex/web-media-effects@^2.7.0":
   version "2.7.0"
@@ -3280,6 +3282,11 @@ bottleneck@^2.18.1:
   version "2.19.5"
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This PR fixes an issue in which Firefox will allow `setLocalDescription` to be called even when all the codecs have been removed from the media line as part of [SPARK-465378](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-465378). This violates RFC8866, which states that at least one codec is required.

A bug has been filed to Firefox about this: https://bugzilla.mozilla.org/show_bug.cgi?id=1857612

Until Firefox fixes this bug, the fix from our end is to add a check in `setLocalDescription` to check the number of fields in the media line. This is similar to what Google does: https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/pc/webrtc_sdp.cc;l=2682;drc=f5bdc89c7395ed24f1b8d196a3bdd6232d5bf771

If the number of fields is less than 4 (i.e. the codecs are missing), then we throw an error.

