### PR TITLE
fix: explicitly allow event handlers to be asynchronous

### DIFF
--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -8,8 +8,10 @@ export enum LocalStreamEventNames {
 }
 
 interface LocalStreamEvents {
-  [LocalStreamEventNames.ConstraintsChange]: TypedEvent<() => void>;
-  [LocalStreamEventNames.OutputTrackChange]: TypedEvent<(track: MediaStreamTrack) => void>;
+  [LocalStreamEventNames.ConstraintsChange]: TypedEvent<() => void | Promise<void>>;
+  [LocalStreamEventNames.OutputTrackChange]: TypedEvent<
+    (track: MediaStreamTrack) => void | Promise<void>
+  >;
 }
 
 export type TrackEffect = BaseEffect;
@@ -20,9 +22,11 @@ type EffectItem = { name: string; effect: TrackEffect };
  * A stream which originates on the local device.
  */
 abstract class _LocalStream extends Stream {
-  [LocalStreamEventNames.ConstraintsChange] = new TypedEvent<() => void>();
+  [LocalStreamEventNames.ConstraintsChange] = new TypedEvent<() => void | Promise<void>>();
 
-  [LocalStreamEventNames.OutputTrackChange] = new TypedEvent<(track: MediaStreamTrack) => void>();
+  [LocalStreamEventNames.OutputTrackChange] = new TypedEvent<
+    (track: MediaStreamTrack) => void | Promise<void>
+  >();
 
   private effects: EffectItem[] = [];
 

--- a/src/media/stream.ts
+++ b/src/media/stream.ts
@@ -6,8 +6,8 @@ export enum StreamEventNames {
 }
 
 interface StreamEvents {
-  [StreamEventNames.MuteStateChange]: TypedEvent<(muted: boolean) => void>;
-  [StreamEventNames.Ended]: TypedEvent<() => void>;
+  [StreamEventNames.MuteStateChange]: TypedEvent<(muted: boolean) => void | Promise<void>>;
+  [StreamEventNames.Ended]: TypedEvent<() => void | Promise<void>>;
 }
 
 /**
@@ -19,9 +19,9 @@ abstract class _Stream {
 
   // TODO: these should be protected, but we need the helper type in ts-events
   // to hide the 'emit' method from TypedEvent.
-  [StreamEventNames.MuteStateChange] = new TypedEvent<(muted: boolean) => void>();
+  [StreamEventNames.MuteStateChange] = new TypedEvent<(muted: boolean) => void | Promise<void>>();
 
-  [StreamEventNames.Ended] = new TypedEvent<() => void>();
+  [StreamEventNames.Ended] = new TypedEvent<() => void | Promise<void>>();
 
   /**
    * Create a Stream from the given values.


### PR DESCRIPTION
This PR explicitly allows all StreamEvents and LocalStreamEvents to have asynchronous handlers.