### PR TITLE
fix: rename WcmeError to WebrtcCoreError

### DIFF
--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -1,3 +1,4 @@
+import { WebrtcCoreError, WebrtcCoreErrorTypes } from '../errors';
 import * as media from '../media';
 import { LocalCameraStream } from '../media/local-camera-stream';
 import { LocalDisplayStream } from '../media/local-display-stream';
@@ -5,33 +6,8 @@ import { LocalMicrophoneStream } from '../media/local-microphone-stream';
 import { LocalSystemAudioStream } from '../media/local-system-audio-stream';
 import { VideoContentHint } from '../media/local-video-stream';
 
-export enum ErrorTypes {
-  DEVICE_PERMISSION_DENIED = 'DEVICE_PERMISSION_DENIED',
-  CREATE_STREAM_FAILED = 'CREATE_CAMERA_STREAM',
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T> = new (...args: any[]) => T;
-
-/**
- * Represents a WCME error, which contains error type and error message.
- */
-export class WcmeError {
-  type: string;
-
-  message: string;
-
-  /**
-   * Creates new error.
-   *
-   * @param type - Error type.
-   * @param message - Error message.
-   */
-  constructor(type: ErrorTypes, message = '') {
-    this.type = type;
-    this.message = message;
-  }
-}
 
 export type AudioDeviceConstraints = Pick<
   MediaTrackConstraints,
@@ -68,8 +44,8 @@ export async function createCameraStream<T extends LocalCameraStream>(
   try {
     stream = await media.getUserMedia({ video: { ...constraints } });
   } catch (error) {
-    throw new WcmeError(
-      ErrorTypes.CREATE_STREAM_FAILED,
+    throw new WebrtcCoreError(
+      WebrtcCoreErrorTypes.CREATE_STREAM_FAILED,
       `Failed to create camera stream: ${error}`
     );
   }
@@ -91,8 +67,8 @@ export async function createMicrophoneStream<T extends LocalMicrophoneStream>(
   try {
     stream = await media.getUserMedia({ audio: { ...constraints } });
   } catch (error) {
-    throw new WcmeError(
-      ErrorTypes.CREATE_STREAM_FAILED,
+    throw new WebrtcCoreError(
+      WebrtcCoreErrorTypes.CREATE_STREAM_FAILED,
       `Failed to create microphone stream: ${error}`
     );
   }
@@ -124,8 +100,8 @@ export async function createCameraAndMicrophoneStreams<
       audio: { ...constraints?.audio },
     });
   } catch (error) {
-    throw new WcmeError(
-      ErrorTypes.CREATE_STREAM_FAILED,
+    throw new WebrtcCoreError(
+      WebrtcCoreErrorTypes.CREATE_STREAM_FAILED,
       `Failed to create camera and microphone streams: ${error}`
     );
   }
@@ -153,8 +129,8 @@ export async function createDisplayStream<T extends LocalDisplayStream>(
   try {
     stream = await media.getDisplayMedia({ video: true });
   } catch (error) {
-    throw new WcmeError(
-      ErrorTypes.CREATE_STREAM_FAILED,
+    throw new WebrtcCoreError(
+      WebrtcCoreErrorTypes.CREATE_STREAM_FAILED,
       `Failed to create display stream: ${error}`
     );
   }
@@ -187,8 +163,8 @@ export async function createDisplayStreamWithAudio<
   try {
     stream = await media.getDisplayMedia({ video: true, audio: true });
   } catch (error) {
-    throw new WcmeError(
-      ErrorTypes.CREATE_STREAM_FAILED,
+    throw new WebrtcCoreError(
+      WebrtcCoreErrorTypes.CREATE_STREAM_FAILED,
       `Failed to create display and system audio streams: ${error}`
     );
   }
@@ -221,7 +197,10 @@ export async function getDevices(deviceKind?: media.DeviceKind): Promise<MediaDe
       media.enumerateDevices
     );
   } catch (error) {
-    throw new WcmeError(ErrorTypes.DEVICE_PERMISSION_DENIED, 'Failed to ensure device permissions');
+    throw new WebrtcCoreError(
+      WebrtcCoreErrorTypes.DEVICE_PERMISSION_DENIED,
+      'Failed to ensure device permissions'
+    );
   }
 
   return devices.filter((v: MediaDeviceInfo) => (deviceKind ? v.kind === deviceKind : true));

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,24 @@
+export enum WebrtcCoreErrorTypes {
+  DEVICE_PERMISSION_DENIED = 'DEVICE_PERMISSION_DENIED',
+  CREATE_STREAM_FAILED = 'CREATE_STREAM_FAILED',
+}
+
+/**
+ * Represents a WebRTC core error, which contains error type and error message.
+ */
+export class WebrtcCoreError {
+  type: string;
+
+  message: string;
+
+  /**
+   * Creates new error.
+   *
+   * @param type - Error type.
+   * @param message - Error message.
+   */
+  constructor(type: WebrtcCoreErrorTypes, message = '') {
+    this.type = type;
+    this.message = message;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as media from './media';
 
 export * from './device/device-management';
+export * from './errors';
 export * from './media/local-audio-stream';
 export * from './media/local-camera-stream';
 export * from './media/local-display-stream';


### PR DESCRIPTION
This PR renames `WcmeError` to `WebrtcCoreError`, and moves the error object to its own file, as part of [WEBEX-365025](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-365025).