### PR TITLE
fix: handle invalid m-line with trailing whitespace

### DIFF
--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -209,7 +209,7 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
         ?.split(/(\r\n|\r|\n)/)
         .filter((line) => line.startsWith('m'))
         .forEach((mediaLine) => {
-          if (mediaLine.split(' ').length < 4) {
+          if (mediaLine.trim().split(' ').length < 4) {
             throw new Error(`Invalid media line ${mediaLine}, expected at least 4 fields`);
           }
         });


### PR DESCRIPTION
This PR fixes the case in which an invalid m-line with a trailing whitespace may be considered to be valid. For example, "m=video 9 UDP/TLS/RTP/SAVPF " should be throwing an error, but the trailing space causes webrtc-core to think it is valid.