### PR TITLE
fix: check muted property for mute getter

### DIFF
--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -60,6 +60,24 @@ abstract class _LocalStream extends Stream {
   /**
    * @inheritdoc
    */
+  protected handleTrackMuted() {
+    if (this.inputTrack.enabled) {
+      super.handleTrackMuted();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected handleTrackUnmuted() {
+    if (this.inputTrack.enabled) {
+      super.handleTrackUnmuted();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
   get muted(): boolean {
     // Calls to `setMuted` will only affect the "enabled" state, but there are specific cases in
     // which the browser may mute the track, which will affect the "muted" state but not the
@@ -76,7 +94,9 @@ abstract class _LocalStream extends Stream {
     if (this.inputTrack.enabled === isMuted) {
       this.inputTrack.enabled = !isMuted;
       // setting `enabled` will not automatically emit MuteStateChange, so we emit it here
-      this[StreamEventNames.MuteStateChange].emit(isMuted);
+      if (!this.inputTrack.muted) {
+        this[StreamEventNames.MuteStateChange].emit(isMuted);
+      }
     }
   }
 

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -61,7 +61,10 @@ abstract class _LocalStream extends Stream {
    * @inheritdoc
    */
   get muted(): boolean {
-    return !this.inputTrack.enabled;
+    // Calls to `setMuted` will only affect the "enabled" state, but there are specific cases in
+    // which the browser may mute the track, which will affect the "muted" state but not the
+    // "enabled" state, e.g. minimizing a shared window or unplugging a shared screen.
+    return !this.inputTrack.enabled || this.inputTrack.muted;
   }
 
   /**

--- a/src/media/stream.ts
+++ b/src/media/stream.ts
@@ -39,14 +39,14 @@ abstract class _Stream {
   /**
    * Handler which is called when a track's mute event fires.
    */
-  private handleTrackMuted() {
+  protected handleTrackMuted() {
     this[StreamEventNames.MuteStateChange].emit(true);
   }
 
   /**
    * Handler which is called when a track's unmute event fires.
    */
-  private handleTrackUnmuted() {
+  protected handleTrackUnmuted() {
     this[StreamEventNames.MuteStateChange].emit(false);
   }
 


### PR DESCRIPTION
This PR also checks the mute property of the track when calling `LocalStream.muted`. This more accurately reflects the mute state of the track; for example, when sharing a window, the track gets muted by the browser when the shared window is minimized.