### PR TITLE
feat: add custom method toJSON for _LocalStream

### DIFF
--- a/src/media/local-stream.spec.ts
+++ b/src/media/local-stream.spec.ts
@@ -199,12 +199,11 @@ describe('LocalStream', () => {
     });
 
     it('should return an object with inputStream, outputStream and effects properties', () => {
-      expect.assertions(7);
+      expect.assertions(6);
 
       const jsonLocalStream = localStream.toJSON();
 
       expect(jsonLocalStream).toHaveProperty('muted');
-      expect(jsonLocalStream).toHaveProperty('enabled');
       expect(jsonLocalStream).toHaveProperty('label');
       expect(jsonLocalStream).toHaveProperty('readyState');
       expect(jsonLocalStream).toHaveProperty('inputStream');

--- a/src/media/local-stream.spec.ts
+++ b/src/media/local-stream.spec.ts
@@ -4,7 +4,7 @@ import { LocalStream, LocalStreamEventNames, TrackEffect } from './local-stream'
 import { StreamEventNames } from './stream';
 
 /**
- * A dummy LocalStream implementation so we can instantiate it for testing.
+ * A dummy LocalStream implementation, so we can instantiate it for testing.
  */
 class TestLocalStream extends LocalStream {}
 
@@ -184,6 +184,37 @@ describe('LocalStream', () => {
       expect(loadSpy).toHaveBeenCalledTimes(1);
       expect(localStream.getEffects()).toStrictEqual([]);
       expect(emitSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('toJSON', () => {
+    it('should be called when JSON.stringify is used', () => {
+      expect.assertions(1);
+
+      const spyToJSON = jest.spyOn(localStream, 'toJSON');
+
+      JSON.stringify(localStream);
+
+      expect(spyToJSON).toHaveBeenCalledTimes(1);
+
+      spyToJSON.mockRestore();
+    });
+
+    it('should return an object with inputStream, outputStream and effects properties', () => {
+      expect.assertions(8);
+
+      const json = localStream.toJSON();
+
+      expect(json).toHaveProperty('inputStream');
+      expect(json.inputStream).toHaveProperty('active');
+      expect(json.inputStream).toHaveProperty('id');
+
+      expect(json).toHaveProperty('outputStream');
+      expect(json.outputStream).toHaveProperty('active');
+      expect(json.outputStream).toHaveProperty('id');
+
+      expect(json).toHaveProperty('effects');
+      expect(Array.isArray(json.effects)).toBe(true);
     });
   });
 });

--- a/src/media/local-stream.spec.ts
+++ b/src/media/local-stream.spec.ts
@@ -188,31 +188,24 @@ describe('LocalStream', () => {
   });
 
   describe('toJSON', () => {
-    it('should be called when JSON.stringify is used', () => {
+    it('should correctly serialize data', () => {
       expect.assertions(1);
 
-      const spyToJSON = jest.spyOn(localStream, 'toJSON');
+      const testLocalStream = new TestLocalStream(mockStream);
+      const jsonLocalStream = localStream.toJSON();
+      const jsonTestLocalStream = testLocalStream.toJSON();
 
-      JSON.stringify(localStream);
-
-      expect(spyToJSON).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(jsonLocalStream)).toStrictEqual(JSON.stringify(jsonTestLocalStream));
     });
 
     it('should return an object with inputStream, outputStream and effects properties', () => {
-      expect.assertions(8);
+      expect.assertions(3);
 
-      const json = localStream.toJSON();
+      const jsonLocalStream = localStream.toJSON();
 
-      expect(json).toHaveProperty('inputStream');
-      expect(json.inputStream).toHaveProperty('active');
-      expect(json.inputStream).toHaveProperty('id');
-
-      expect(json).toHaveProperty('outputStream');
-      expect(json.outputStream).toHaveProperty('active');
-      expect(json.outputStream).toHaveProperty('id');
-
-      expect(json).toHaveProperty('effects');
-      expect(Array.isArray(json.effects)).toBe(true);
+      expect(jsonLocalStream).toHaveProperty('inputStream');
+      expect(jsonLocalStream).toHaveProperty('outputStream');
+      expect(jsonLocalStream).toHaveProperty('effects');
     });
   });
 });

--- a/src/media/local-stream.spec.ts
+++ b/src/media/local-stream.spec.ts
@@ -196,8 +196,6 @@ describe('LocalStream', () => {
       JSON.stringify(localStream);
 
       expect(spyToJSON).toHaveBeenCalledTimes(1);
-
-      spyToJSON.mockRestore();
     });
 
     it('should return an object with inputStream, outputStream and effects properties', () => {

--- a/src/media/local-stream.spec.ts
+++ b/src/media/local-stream.spec.ts
@@ -199,10 +199,14 @@ describe('LocalStream', () => {
     });
 
     it('should return an object with inputStream, outputStream and effects properties', () => {
-      expect.assertions(3);
+      expect.assertions(7);
 
       const jsonLocalStream = localStream.toJSON();
 
+      expect(jsonLocalStream).toHaveProperty('muted');
+      expect(jsonLocalStream).toHaveProperty('enabled');
+      expect(jsonLocalStream).toHaveProperty('label');
+      expect(jsonLocalStream).toHaveProperty('readyState');
       expect(jsonLocalStream).toHaveProperty('inputStream');
       expect(jsonLocalStream).toHaveProperty('outputStream');
       expect(jsonLocalStream).toHaveProperty('effects');

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -291,13 +291,13 @@ abstract class _LocalStream extends Stream {
    */
   toJSON() {
     return {
+      muted: this.muted,
+      enabled: this.inputTrack.enabled,
+      label: this.label,
+      readyState: this.readyState,
       inputStream: {
         active: this.inputStream.active,
         id: this.inputStream.id,
-        muted: this.muted,
-        label: this.label,
-        enabled: this.inputTrack.enabled,
-        readyState: this.readyState,
       },
       outputStream: {
         active: this.outputStream.active,

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -284,6 +284,32 @@ abstract class _LocalStream extends Stream {
   }
 
   /**
+   * Method to serialize data about input, output streams
+   * and also effects from _LocalStream.
+   *
+   * @returns - A JSON-compatible object representation with data from _LocalStream.
+   */
+  toJSON() {
+    return {
+      inputStream: {
+        active: this.inputStream.active,
+        id: this.inputStream.id,
+      },
+      outputStream: {
+        active: this.outputStream.active,
+        id: this.outputStream.id,
+      },
+      effects: this.effects.map((effect) => {
+        return {
+          id: effect.id,
+          kind: effect.kind,
+          isEnabled: effect.isEnabled,
+        };
+      }),
+    };
+  }
+
+  /**
    * Cleanup the local effects.
    */
   async disposeEffects(): Promise<void> {

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -292,12 +292,13 @@ abstract class _LocalStream extends Stream {
   toJSON() {
     return {
       muted: this.muted,
-      enabled: this.inputTrack.enabled,
       label: this.label,
       readyState: this.readyState,
       inputStream: {
         active: this.inputStream.active,
         id: this.inputStream.id,
+        enabled: this.inputTrack.enabled,
+        muted: this.inputTrack.muted,
       },
       outputStream: {
         active: this.outputStream.active,

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -294,6 +294,10 @@ abstract class _LocalStream extends Stream {
       inputStream: {
         active: this.inputStream.active,
         id: this.inputStream.id,
+        muted: this.muted,
+        label: this.label,
+        enabled: this.inputTrack.enabled,
+        readyState: this.readyState,
       },
       outputStream: {
         active: this.outputStream.active,

--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -285,9 +285,9 @@ abstract class _LocalStream extends Stream {
 
   /**
    * Method to serialize data about input, output streams
-   * and also effects from _LocalStream.
+   * and also effects from LocalStream.
    *
-   * @returns - A JSON-compatible object representation with data from _LocalStream.
+   * @returns - A JSON-compatible object representation with data from LocalStream.
    */
   toJSON() {
     return {


### PR DESCRIPTION
The main purpose of this update is to make better work with LocalStream and smoother debugging for [webex-js-sdk](https://github.com/webex/webex-js-sdk). Mainly it should get rid of custom overrides for objects and give more useful information in better structure. See current overrides here https://github.com/webex/webex-js-sdk/pull/3148/commits/4089648179ee2566cab1e7e718c6ac5908c83eb7

This PR consists of the following updates: 
- update for `_LocalStream` object and add custom `toJSON` method
- added new test cases for `_LocalStream` 