### PR TITLE
feat: set/create events

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -37,9 +37,9 @@
     "WCME",
     "webex",
     "webrtc",
-    "createoffer",
-    "setlocaldescription",
-    "setremotedescription"
+    "createofferonsuccess",
+    "setlocaldescriptiononsuccess",
+    "setremotedescriptiononsuccess"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/cspell.json
+++ b/cspell.json
@@ -37,7 +37,9 @@
     "WCME",
     "webex",
     "webrtc",
-    "sdpchange"
+    "createoffer",
+    "setlocaldescription",
+    "setremotedescription"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/cspell.json
+++ b/cspell.json
@@ -38,6 +38,7 @@
     "webex",
     "webrtc",
     "createofferonsuccess",
+    "createansweronsuccess",
     "setlocaldescriptiononsuccess",
     "setremotedescriptiononsuccess"
   ],

--- a/cspell.json
+++ b/cspell.json
@@ -36,7 +36,8 @@
     "Wcme",
     "WCME",
     "webex",
-    "webrtc"
+    "webrtc",
+    "sdpchange"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webrtc-core",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/umd/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webrtc-core",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "browser": "dist/umd/index.js",

--- a/src/mocks/rtc-peer-connection-stub.ts
+++ b/src/mocks/rtc-peer-connection-stub.ts
@@ -7,6 +7,9 @@
  * This stub exists to act as a scaffold for creating a mock.
  */
 class RTCPeerConnectionStub {
+  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit> {
+    return new Promise(() => {});
+  }
   createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit> {
     return new Promise(() => {});
   }

--- a/src/mocks/rtc-peer-connection-stub.ts
+++ b/src/mocks/rtc-peer-connection-stub.ts
@@ -13,7 +13,15 @@ class RTCPeerConnectionStub {
   getStats(): Promise<any> {
     return new Promise(() => {});
   }
-  setLocalDescription(): Promise<any> {
+  setLocalDescription(
+    description?: RTCSessionDescription | RTCSessionDescriptionInit
+  ): Promise<void> {
+    return new Promise(() => {});
+  }
+
+  setRemoteDescription(
+    description?: RTCSessionDescription | RTCSessionDescriptionInit
+  ): Promise<void> {
     return new Promise(() => {});
   }
   onconnectionstatechange: () => void = () => {};

--- a/src/peer-connection.spec.ts
+++ b/src/peer-connection.spec.ts
@@ -273,7 +273,7 @@ describe('PeerConnection', () => {
       mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
       pc = new PeerConnection();
       createOfferSpy = jest.spyOn(pc, 'createOffer');
-      pc.on(PeerConnection.Events.CreateOffer, callback);
+      pc.on(PeerConnection.Events.CreateOfferOnSuccess, callback);
     });
 
     it('should emit event when createOffer called', async () => {
@@ -317,7 +317,7 @@ describe('PeerConnection', () => {
       });
       setLocalDescriptionSpy = jest.spyOn(mockPc, 'setLocalDescription');
       pc = new PeerConnection();
-      pc.on(PeerConnection.Events.SetLocalDescription, callback);
+      pc.on(PeerConnection.Events.SetLocalDescriptionOnSuccess, callback);
     });
 
     it('sets the local description with an SDP offer', async () => {
@@ -382,7 +382,7 @@ describe('PeerConnection', () => {
       mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
       pc = new PeerConnection();
       setRemoteDescriptionSpy = jest.spyOn(pc, 'setRemoteDescription');
-      pc.on(PeerConnection.Events.SetRemoteDescription, callback);
+      pc.on(PeerConnection.Events.SetRemoteDescriptionOnSuccess, callback);
     });
 
     it('should emit event when setRemoteDescription called', async () => {

--- a/src/peer-connection.spec.ts
+++ b/src/peer-connection.spec.ts
@@ -250,7 +250,6 @@ describe('PeerConnection', () => {
 
   describe('createOffer', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
-    let shouldCreateOfferThrow = false;
     let createOfferSpy: jest.SpyInstance;
     const callback = jest.fn();
     let pc: PeerConnection;
@@ -263,13 +262,7 @@ describe('PeerConnection', () => {
       jest.clearAllMocks();
       mockPc = mocked(new RTCPeerConnectionStub(), true);
       mockPc.createOffer.mockImplementation(() => {
-        return new Promise((resolve, reject) => {
-          if (shouldCreateOfferThrow) {
-            reject(new Error());
-          } else {
-            resolve(mockedReturnedOffer);
-          }
-        });
+        return Promise.resolve(mockedReturnedOffer);
       });
       mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
       pc = new PeerConnection();
@@ -279,7 +272,6 @@ describe('PeerConnection', () => {
 
     it('should emit event when createOffer called', async () => {
       expect.hasAssertions();
-      shouldCreateOfferThrow = false;
       const options: RTCOfferOptions = {
         iceRestart: true,
       };
@@ -291,7 +283,9 @@ describe('PeerConnection', () => {
 
     it('should not emit event when createOffer failed', async () => {
       expect.hasAssertions();
-      shouldCreateOfferThrow = true;
+      mockPc.createOffer.mockImplementation(() => {
+        return Promise.reject(new Error());
+      });
       const offerPromise = pc.createOffer(null as unknown as RTCOfferOptions);
       await expect(offerPromise).rejects.toThrow(Error);
       expect(createOfferSpy).toHaveBeenCalledWith(null);
@@ -301,7 +295,6 @@ describe('PeerConnection', () => {
 
   describe('setLocalDescription', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
-    let shouldSetLocalDescriptionThrow = false;
     let setLocalDescriptionSpy: jest.SpyInstance;
     const callback = jest.fn();
     let pc: PeerConnection;
@@ -311,13 +304,7 @@ describe('PeerConnection', () => {
       mockPc = mocked(new RTCPeerConnectionStub(), true);
       mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
       mockPc.setLocalDescription.mockImplementation(() => {
-        return new Promise((resolve, reject) => {
-          if (shouldSetLocalDescriptionThrow) {
-            reject(new Error());
-          } else {
-            resolve();
-          }
-        });
+        return Promise.resolve();
       });
       setLocalDescriptionSpy = jest.spyOn(mockPc, 'setLocalDescription');
       pc = new PeerConnection();
@@ -326,20 +313,17 @@ describe('PeerConnection', () => {
 
     it('sets the local description with an SDP offer', async () => {
       expect.hasAssertions();
-      shouldSetLocalDescriptionThrow = false;
       const description = { type: 'offer', sdp: 'fake sdp' } as RTCSessionDescriptionInit;
       pc.setLocalDescription(description);
       expect(setLocalDescriptionSpy).toHaveBeenCalledWith(description);
     });
     it('sets the local description with no SDP offer', async () => {
       expect.hasAssertions();
-      shouldSetLocalDescriptionThrow = false;
       pc.setLocalDescription();
       expect(setLocalDescriptionSpy).toHaveBeenCalledWith(undefined);
     });
     it('throws an error when the SDP has an invalid media line on Firefox', async () => {
       expect.hasAssertions();
-      shouldSetLocalDescriptionThrow = false;
       jest.spyOn(BrowserInfo, 'isFirefox').mockReturnValue(true);
       await expect(
         pc.setLocalDescription({ type: 'offer', sdp: 'm=video 9 UDP/TLS/RTP' })
@@ -348,7 +332,6 @@ describe('PeerConnection', () => {
 
     it('should emit event when setLocalDescription called', async () => {
       expect.hasAssertions();
-      shouldSetLocalDescriptionThrow = false;
       const options = {
         sdp: 'blah',
       };
@@ -359,7 +342,9 @@ describe('PeerConnection', () => {
 
     it('should not emit event when setLocalDescription failed', async () => {
       expect.hasAssertions();
-      shouldSetLocalDescriptionThrow = true;
+      mockPc.setLocalDescription.mockImplementation(() => {
+        return Promise.reject(new Error());
+      });
       const options = {
         sdp: 'reject',
       };
@@ -372,7 +357,6 @@ describe('PeerConnection', () => {
 
   describe('setRemoteDescription', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
-    let shouldSetRemoteDescriptionThrow = false;
     let setRemoteDescriptionSpy: jest.SpyInstance;
     const callback = jest.fn();
     let pc: PeerConnection;
@@ -381,13 +365,7 @@ describe('PeerConnection', () => {
       jest.clearAllMocks();
       mockPc = mocked(new RTCPeerConnectionStub(), true);
       mockPc.setRemoteDescription.mockImplementation(() => {
-        return new Promise((resolve, reject) => {
-          if (shouldSetRemoteDescriptionThrow) {
-            reject(new Error());
-          } else {
-            resolve();
-          }
-        });
+        return Promise.resolve();
       });
       mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
       pc = new PeerConnection();
@@ -397,7 +375,6 @@ describe('PeerConnection', () => {
 
     it('should emit event when setRemoteDescription called', async () => {
       expect.hasAssertions();
-      shouldSetRemoteDescriptionThrow = false;
       const options = {
         sdp: 'blah',
       };
@@ -408,7 +385,9 @@ describe('PeerConnection', () => {
 
     it('should not emit event when setRemoteDescription failed', async () => {
       expect.hasAssertions();
-      shouldSetRemoteDescriptionThrow = true;
+      mockPc.setRemoteDescription.mockImplementation(() => {
+        return Promise.reject(new Error());
+      });
       const options = {
         sdp: 'reject',
       };

--- a/src/peer-connection.spec.ts
+++ b/src/peer-connection.spec.ts
@@ -250,6 +250,7 @@ describe('PeerConnection', () => {
 
   describe('createOffer', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
+    let shouldCreateOfferThrow = false;
     let createOfferSpy: jest.SpyInstance;
     const callback = jest.fn();
     let pc: PeerConnection;
@@ -261,9 +262,9 @@ describe('PeerConnection', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockPc = mocked(new RTCPeerConnectionStub(), true);
-      mockPc.createOffer.mockImplementation((description) => {
+      mockPc.createOffer.mockImplementation(() => {
         return new Promise((resolve, reject) => {
-          if (!description) {
+          if (shouldCreateOfferThrow) {
             reject(new Error());
           } else {
             resolve(mockedReturnedOffer);
@@ -278,6 +279,7 @@ describe('PeerConnection', () => {
 
     it('should emit event when createOffer called', async () => {
       expect.hasAssertions();
+      shouldCreateOfferThrow = false;
       const options: RTCOfferOptions = {
         iceRestart: true,
       };
@@ -289,6 +291,7 @@ describe('PeerConnection', () => {
 
     it('should not emit event when createOffer failed', async () => {
       expect.hasAssertions();
+      shouldCreateOfferThrow = true;
       const offerPromise = pc.createOffer(null as unknown as RTCOfferOptions);
       await expect(offerPromise).rejects.toThrow(Error);
       expect(createOfferSpy).toHaveBeenCalledWith(null);
@@ -298,6 +301,7 @@ describe('PeerConnection', () => {
 
   describe('setLocalDescription', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
+    let shouldSetLocalDescriptionThrow = false;
     let setLocalDescriptionSpy: jest.SpyInstance;
     const callback = jest.fn();
     let pc: PeerConnection;
@@ -306,9 +310,9 @@ describe('PeerConnection', () => {
       jest.clearAllMocks();
       mockPc = mocked(new RTCPeerConnectionStub(), true);
       mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
-      mockPc.setLocalDescription.mockImplementation((description) => {
+      mockPc.setLocalDescription.mockImplementation(() => {
         return new Promise((resolve, reject) => {
-          if (description?.sdp === 'reject') {
+          if (shouldSetLocalDescriptionThrow) {
             reject(new Error());
           } else {
             resolve();
@@ -322,17 +326,20 @@ describe('PeerConnection', () => {
 
     it('sets the local description with an SDP offer', async () => {
       expect.hasAssertions();
+      shouldSetLocalDescriptionThrow = false;
       const description = { type: 'offer', sdp: 'fake sdp' } as RTCSessionDescriptionInit;
       pc.setLocalDescription(description);
       expect(setLocalDescriptionSpy).toHaveBeenCalledWith(description);
     });
     it('sets the local description with no SDP offer', async () => {
       expect.hasAssertions();
+      shouldSetLocalDescriptionThrow = false;
       pc.setLocalDescription();
       expect(setLocalDescriptionSpy).toHaveBeenCalledWith(undefined);
     });
     it('throws an error when the SDP has an invalid media line on Firefox', async () => {
       expect.hasAssertions();
+      shouldSetLocalDescriptionThrow = false;
       jest.spyOn(BrowserInfo, 'isFirefox').mockReturnValue(true);
       await expect(
         pc.setLocalDescription({ type: 'offer', sdp: 'm=video 9 UDP/TLS/RTP' })
@@ -341,6 +348,7 @@ describe('PeerConnection', () => {
 
     it('should emit event when setLocalDescription called', async () => {
       expect.hasAssertions();
+      shouldSetLocalDescriptionThrow = false;
       const options = {
         sdp: 'blah',
       };
@@ -351,6 +359,7 @@ describe('PeerConnection', () => {
 
     it('should not emit event when setLocalDescription failed', async () => {
       expect.hasAssertions();
+      shouldSetLocalDescriptionThrow = true;
       const options = {
         sdp: 'reject',
       };
@@ -363,6 +372,7 @@ describe('PeerConnection', () => {
 
   describe('setRemoteDescription', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
+    let shouldSetRemoteDescriptionThrow = false;
     let setRemoteDescriptionSpy: jest.SpyInstance;
     const callback = jest.fn();
     let pc: PeerConnection;
@@ -370,9 +380,9 @@ describe('PeerConnection', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockPc = mocked(new RTCPeerConnectionStub(), true);
-      mockPc.setRemoteDescription.mockImplementation((description) => {
+      mockPc.setRemoteDescription.mockImplementation(() => {
         return new Promise((resolve, reject) => {
-          if (description?.sdp === 'reject') {
+          if (shouldSetRemoteDescriptionThrow) {
             reject(new Error());
           } else {
             resolve();
@@ -387,6 +397,7 @@ describe('PeerConnection', () => {
 
     it('should emit event when setRemoteDescription called', async () => {
       expect.hasAssertions();
+      shouldSetRemoteDescriptionThrow = false;
       const options = {
         sdp: 'blah',
       };
@@ -397,6 +408,7 @@ describe('PeerConnection', () => {
 
     it('should not emit event when setRemoteDescription failed', async () => {
       expect.hasAssertions();
+      shouldSetRemoteDescriptionThrow = true;
       const options = {
         sdp: 'reject',
       };

--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -29,6 +29,7 @@ enum PeerConnectionEvents {
   IceGatheringStateChange = 'icegatheringstatechange',
   ConnectionStateChange = 'connectionstatechange',
   CreateOfferOnSuccess = 'createofferonsuccess',
+  CreateAnswerOnSuccess = 'createansweronsuccess',
   SetLocalDescriptionOnSuccess = 'setlocaldescriptiononsuccess',
   SetRemoteDescriptionOnSuccess = 'setremotedescriptiononsuccess',
 }
@@ -37,6 +38,7 @@ interface PeerConnectionEventHandlers extends EventMap {
   [PeerConnectionEvents.IceGatheringStateChange]: (ev: IceGatheringStateChangeEvent) => void;
   [PeerConnectionEvents.ConnectionStateChange]: (state: ConnectionState) => void;
   [PeerConnectionEvents.CreateOfferOnSuccess]: (offer: RTCSessionDescriptionInit) => void;
+  [PeerConnectionEvents.CreateAnswerOnSuccess]: (answer: RTCSessionDescriptionInit) => void;
   [PeerConnectionEvents.SetLocalDescriptionOnSuccess]: (
     description: RTCSessionDescription | RTCSessionDescriptionInit
   ) => void;
@@ -183,7 +185,10 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
    *     other peer.
    */
   async createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit> {
-    return this.pc.createAnswer(options);
+    return this.pc.createAnswer(options).then((answer) => {
+      this.emit(PeerConnection.Events.CreateAnswerOnSuccess, answer);
+      return answer;
+    });
   }
 
   /**

--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -28,19 +28,19 @@ type IceGatheringStateChangeEvent = {
 enum PeerConnectionEvents {
   IceGatheringStateChange = 'icegatheringstatechange',
   ConnectionStateChange = 'connectionstatechange',
-  CreateOffer = 'createoffer',
-  SetLocalDescription = 'setlocaldescription',
-  SetRemoteDescription = 'setremotedescription',
+  CreateOfferOnSuccess = 'createofferonsuccess',
+  SetLocalDescriptionOnSuccess = 'setlocaldescriptiononsuccess',
+  SetRemoteDescriptionOnSuccess = 'setremotedescriptiononsuccess',
 }
 
 interface PeerConnectionEventHandlers extends EventMap {
   [PeerConnectionEvents.IceGatheringStateChange]: (ev: IceGatheringStateChangeEvent) => void;
   [PeerConnectionEvents.ConnectionStateChange]: (state: ConnectionState) => void;
-  [PeerConnectionEvents.CreateOffer]: (offer: RTCSessionDescriptionInit) => void;
-  [PeerConnectionEvents.SetLocalDescription]: (
+  [PeerConnectionEvents.CreateOfferOnSuccess]: (offer: RTCSessionDescriptionInit) => void;
+  [PeerConnectionEvents.SetLocalDescriptionOnSuccess]: (
     description: RTCSessionDescription | RTCSessionDescriptionInit
   ) => void;
-  [PeerConnectionEvents.SetRemoteDescription]: (
+  [PeerConnectionEvents.SetRemoteDescriptionOnSuccess]: (
     description: RTCSessionDescription | RTCSessionDescriptionInit
   ) => void;
 }
@@ -198,7 +198,7 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
    */
   async createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit> {
     return this.pc.createOffer(options).then((offer) => {
-      this.emit(PeerConnection.Events.CreateOffer, offer);
+      this.emit(PeerConnection.Events.CreateOfferOnSuccess, offer);
       return offer;
     });
   }
@@ -231,7 +231,7 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
 
     return this.pc.setLocalDescription(description).then(() => {
       if (description) {
-        this.emit(PeerConnection.Events.SetLocalDescription, description);
+        this.emit(PeerConnection.Events.SetLocalDescriptionOnSuccess, description);
       }
     });
   }
@@ -249,7 +249,7 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
     description: RTCSessionDescription | RTCSessionDescriptionInit
   ): Promise<void> {
     return this.pc.setRemoteDescription(description).then(() => {
-      this.emit(PeerConnection.Events.SetRemoteDescription, description);
+      this.emit(PeerConnection.Events.SetRemoteDescriptionOnSuccess, description);
     });
   }
 


### PR DESCRIPTION
Added events that will be called on success operations on offer/answer/description

This includes
- `CreateOfferOnSuccess` - when `createOffer` succeeded
- `CreateAnswerOnSuccess` - when `createAnswer` succeeded
- `SetLocalDescriptionOnSuccess` - when `setLocalDescription` succeeded
- `SetRemoteDescriptionOnSuccess` - when `setRemoteDescription` succeeded
