### PR TITLE
fix: dispose effects on call to LocalStream.stop

### DIFF
--- a/src/media/local-stream.ts
+++ b/src/media/local-stream.ts
@@ -217,6 +217,7 @@ abstract class _LocalStream extends Stream {
   stop(): void {
     this.inputTrack.stop();
     this.outputTrack.stop();
+    this.disposeEffects();
     // calling stop() will not automatically emit Ended, so we emit it here
     this[StreamEventNames.Ended].emit();
   }


### PR DESCRIPTION
This PR simply disposes any effects added to the `LocalStream` when `LocalStream.stop` is called. It is being done as part of https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-515171.

It is reasonable to expect that once a stream has been stopped, its effects should be disposed. Not disposing the effects means using up computing resources on effects that are no longer used. A common example is switching camera devices while VBG is enabled, which would stop the old track and add a new effect on the new track.