### PR TITLE
feat: expose separate events for ice and dtls connecting state

### DIFF
--- a/src/connection-state-handler.spec.ts
+++ b/src/connection-state-handler.spec.ts
@@ -29,13 +29,13 @@ describe('ConnectionStateHandler', () => {
     const connStateHandler = new ConnectionStateHandler(fakeCallback);
 
     connStateHandler.on(ConnectionStateHandler.Events.ConnectionStateChanged, (state) => {
-      expect(state).toStrictEqual(ConnectionState.Connecting);
+      expect(state).toStrictEqual(ConnectionState.ConnectingIce);
     });
 
     fakeIceState = 'checking';
     connStateHandler.onIceConnectionStateChange();
 
-    expect(connStateHandler.getConnectionState()).toStrictEqual(ConnectionState.Connecting);
+    expect(connStateHandler.getConnectionState()).toStrictEqual(ConnectionState.ConnectingIce);
   });
 
   it("updates connection state on RTCPeerConnection's connection state change", () => {
@@ -43,13 +43,13 @@ describe('ConnectionStateHandler', () => {
     const connStateHandler = new ConnectionStateHandler(fakeCallback);
 
     connStateHandler.on(ConnectionStateHandler.Events.ConnectionStateChanged, (state) => {
-      expect(state).toStrictEqual(ConnectionState.Connecting);
+      expect(state).toStrictEqual(ConnectionState.ConnectingIce);
     });
 
     fakeConnectionState = 'connecting';
     connStateHandler.onConnectionStateChange();
 
-    expect(connStateHandler.getConnectionState()).toStrictEqual(ConnectionState.Connecting);
+    expect(connStateHandler.getConnectionState()).toStrictEqual(ConnectionState.ConnectingIce);
   });
 
   // test matrix for all possible combinations of iceConnectionState and connectionState
@@ -61,28 +61,28 @@ describe('ConnectionStateHandler', () => {
     expected: ConnectionState;
   }> = [
     { iceState: 'new', connState: 'new', expected: ConnectionState.New },
-    { iceState: 'new', connState: 'connecting', expected: ConnectionState.Connecting },
-    { iceState: 'new', connState: 'connected', expected: ConnectionState.Connecting },
+    { iceState: 'new', connState: 'connecting', expected: ConnectionState.ConnectingIce },
+    { iceState: 'new', connState: 'connected', expected: ConnectionState.ConnectingIce },
     { iceState: 'new', connState: 'disconnected', expected: ConnectionState.Disconnected },
     { iceState: 'new', connState: 'failed', expected: ConnectionState.Failed },
     { iceState: 'new', connState: 'closed', expected: ConnectionState.Closed },
 
-    { iceState: 'checking', connState: 'new', expected: ConnectionState.Connecting },
-    { iceState: 'checking', connState: 'connecting', expected: ConnectionState.Connecting },
-    { iceState: 'checking', connState: 'connected', expected: ConnectionState.Connecting },
+    { iceState: 'checking', connState: 'new', expected: ConnectionState.ConnectingIce },
+    { iceState: 'checking', connState: 'connecting', expected: ConnectionState.ConnectingIce },
+    { iceState: 'checking', connState: 'connected', expected: ConnectionState.ConnectingIce },
     { iceState: 'checking', connState: 'disconnected', expected: ConnectionState.Disconnected },
     { iceState: 'checking', connState: 'failed', expected: ConnectionState.Failed },
     { iceState: 'checking', connState: 'closed', expected: ConnectionState.Closed },
 
-    { iceState: 'connected', connState: 'new', expected: ConnectionState.Connecting },
-    { iceState: 'connected', connState: 'connecting', expected: ConnectionState.Connecting },
+    { iceState: 'connected', connState: 'new', expected: ConnectionState.ConnectingIce },
+    { iceState: 'connected', connState: 'connecting', expected: ConnectionState.ConnectingDtls },
     { iceState: 'connected', connState: 'connected', expected: ConnectionState.Connected },
     { iceState: 'connected', connState: 'disconnected', expected: ConnectionState.Disconnected },
     { iceState: 'connected', connState: 'failed', expected: ConnectionState.Failed },
     { iceState: 'connected', connState: 'closed', expected: ConnectionState.Closed },
 
-    { iceState: 'completed', connState: 'new', expected: ConnectionState.Connecting },
-    { iceState: 'completed', connState: 'connecting', expected: ConnectionState.Connecting },
+    { iceState: 'completed', connState: 'new', expected: ConnectionState.ConnectingIce },
+    { iceState: 'completed', connState: 'connecting', expected: ConnectionState.ConnectingDtls },
     { iceState: 'completed', connState: 'connected', expected: ConnectionState.Connected },
     { iceState: 'completed', connState: 'disconnected', expected: ConnectionState.Disconnected },
     { iceState: 'completed', connState: 'failed', expected: ConnectionState.Failed },

--- a/src/connection-state-handler.ts
+++ b/src/connection-state-handler.ts
@@ -6,7 +6,8 @@ export enum ConnectionState {
   New = 'New', // connection attempt has not been started
   Closed = 'Closed', // connection closed, there is no way to move out of this state
   Connected = 'Connected', // both ICE and DTLS connections are established, media is flowing
-  Connecting = 'Connecting', // initial connection attempt in progress
+  ConnectingIce = 'ConnectingIce', // initial connection attempt in progress
+  ConnectingDtls = 'ConnectingDtls', // initial connection attempt in progress
   Disconnected = 'Disconnected', // connection lost temporarily, the browser is trying to re-establish it automatically
   Failed = 'Failed', // connection failed, an ICE restart is required
 }
@@ -96,8 +97,13 @@ export class ConnectionStateHandler extends EventEmitter<ConnectionStateEventHan
       mediaConnectionState = ConnectionState.Disconnected;
     } else if (connectionStates.every((value) => value === 'connected' || value === 'completed')) {
       mediaConnectionState = ConnectionState.Connected;
+    } else if (
+      (iceState === 'connected' || iceState === 'completed') &&
+      connectionState === 'connecting'
+    ) {
+      mediaConnectionState = ConnectionState.ConnectingDtls;
     } else {
-      mediaConnectionState = ConnectionState.Connecting;
+      mediaConnectionState = ConnectionState.ConnectingIce;
     }
 
     logger.log(

--- a/src/peer-connection.spec.ts
+++ b/src/peer-connection.spec.ts
@@ -234,7 +234,7 @@ describe('PeerConnection', () => {
       const connectionStateHandler = getInstantiatedConnectionStateHandler();
 
       pc.on(PeerConnection.Events.ConnectionStateChange, (state) => {
-        expect(state).toStrictEqual(ConnectionState.Connecting);
+        expect(state).toStrictEqual(ConnectionState.ConnectingIce);
       });
 
       // verify that PeerConnection listens for the right event
@@ -244,7 +244,7 @@ describe('PeerConnection', () => {
 
       // trigger the fake event from ConnectionStateHandler
       const connectionStateHandlerListener = connectionStateHandler.on.mock.calls[0][1];
-      connectionStateHandlerListener(ConnectionState.Connecting);
+      connectionStateHandlerListener(ConnectionState.ConnectingIce);
     });
   });
   describe('createAnswer', () => {


### PR DESCRIPTION
This PR implements exposing two events instead of one to divide states for `Ice Connecting Phase`, and `DTLS Connectin Phase`.
The purpose is to enable easier finding out at which part in JS-SDK we are failing to connect to our backend.
Currently evaluation is done in JS-SDK, but it uses internal objects of webrtc-core, which should not be a desired way.

My and Marcin proposal is to separate events for ICE and DTLS phases. However, I guess we could also expose some getter for `ice connection state`. 