### PR TITLE
feat: expose ConnectionType for easier usage of getCurrentConnectionType

### DIFF
--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -404,4 +404,4 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
 }
 
 export { ConnectionState } from './connection-state-handler';
-export { MediaStreamTrackKind, PeerConnection, RTCDataChannelOptions };
+export { ConnectionType, MediaStreamTrackKind, PeerConnection, RTCDataChannelOptions };


### PR DESCRIPTION
This PR exposes `ConnectionType` type,
It's a missing part to be able to use getCurrentConnectionType comfortably.