### PR TITLE
feat: update typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "semantic-release": "^19.0.2",
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.3",
-    "typescript": "^4.4.3",
+    "typescript": "5.5.2",
     "yarn": "^1.22.18"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "semantic-release": "^19.0.2",
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.3",
-    "typescript": "5.5.2",
+    "typescript": "^5.5.2",
     "yarn": "^1.22.18"
   },
   "scripts": {

--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -49,7 +49,6 @@ describe('Device Management', () => {
         noiseSuppression: false,
         sampleRate: 48000,
         sampleSize: 16,
-        suppressLocalAudioPlayback: false,
       });
       expect(media.getUserMedia).toHaveBeenCalledWith({
         audio: {
@@ -60,7 +59,6 @@ describe('Device Management', () => {
           noiseSuppression: false,
           sampleRate: 48000,
           sampleSize: 16,
-          suppressLocalAudioPlayback: false,
         },
       });
     });

--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -18,7 +18,6 @@ export type AudioDeviceConstraints = Pick<
   | 'noiseSuppression'
   | 'sampleRate'
   | 'sampleSize'
-  | 'suppressLocalAudioPlayback'
 >;
 
 export type VideoDeviceConstraints = Pick<

--- a/src/media/local-audio-stream.ts
+++ b/src/media/local-audio-stream.ts
@@ -4,7 +4,7 @@ import { LocalStream, LocalStreamEventNames } from './local-stream';
 // These are the audio constraints that can be applied via applyConstraints.
 export type AppliableAudioConstraints = Pick<
   MediaTrackConstraints,
-  'autoGainControl' | 'echoCancellation' | 'noiseSuppression' | 'suppressLocalAudioPlayback'
+  'autoGainControl' | 'echoCancellation' | 'noiseSuppression'
 >;
 
 /**

--- a/src/mocks/create-permission-status.ts
+++ b/src/mocks/create-permission-status.ts
@@ -16,4 +16,5 @@ export const createPermissionStatus = (state: PermissionState): PermissionStatus
   addEventListener: () => {},
   removeEventListener: () => {},
   dispatchEvent: (event: Event): boolean => true,
+  name: '',
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,6 @@
     // "noUnusedLocals": true /* Report errors on unused locals. */,
     // "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "suppressImplicitAnyIndexErrors": true /* Suppresses errors about implicit anys when indexing into objects. */,
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true, /* Include 'undefined' in index signature results */
     // "noImplicitOverride": true, /* Ensure overriding members in derived classes are marked with an 'override' modifier. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -11029,7 +11029,12 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.4.3, typescript@~4.8.4:
+typescript@5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
+  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+
+typescript@~4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
This PR updates the typescript version. It's needed to be able to use directly `RTCPeerConnectionIceErrorEvent` which is not available in current typescript version. 

Typescript options `suppressImplicitAnyIndexErrors` is getting deprecated. It's removal causes not being able to compile because `suppressLocalAudioPlayback` is not defined for `MediaTrackConstraints`. 
`suppressLocalAudioPlayback` is experimental, thus it's not in typescript yet.

Are we safe to remove this flag from constraints or we should add an typescript option which will supress deprecation of `suppressImplicitAnyIndexErrors`.