### PR TITLE
feat: expose icecandidateerror event

### DIFF
--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -28,6 +28,7 @@ type IceGatheringStateChangeEvent = {
 enum PeerConnectionEvents {
   IceGatheringStateChange = 'icegatheringstatechange',
   IceCandidate = 'icecandidate',
+  IceCandidateError = 'icecandidateerror',
   PeerConnectionStateChange = 'peerconnectionstatechange',
   IceConnectionStateChange = 'iceconnectionstatechange',
   CreateOfferOnSuccess = 'createofferonsuccess',
@@ -39,6 +40,7 @@ enum PeerConnectionEvents {
 interface PeerConnectionEventHandlers extends EventMap {
   [PeerConnectionEvents.IceGatheringStateChange]: (ev: IceGatheringStateChangeEvent) => void;
   [PeerConnectionEvents.IceCandidate]: (ev: RTCPeerConnectionIceEvent) => void;
+  [PeerConnectionEvents.IceCandidateError]: (ev: RTCPeerConnectionIceErrorEvent) => void;
   [PeerConnectionEvents.PeerConnectionStateChange]: (state: RTCPeerConnectionState) => void;
   [PeerConnectionEvents.IceConnectionStateChange]: (state: RTCIceConnectionState) => void;
   [PeerConnectionEvents.CreateOfferOnSuccess]: (offer: RTCSessionDescriptionInit) => void;
@@ -112,6 +114,12 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
     /* eslint-disable jsdoc/require-jsdoc */
     this.pc.onicecandidate = (ev: RTCPeerConnectionIceEvent) => {
       this.emit(PeerConnection.Events.IceCandidate, ev);
+    };
+
+    this.pc.onicecandidateerror = (ev: Event) => {
+      const event = ev as RTCPeerConnectionIceErrorEvent;
+
+      this.emit(PeerConnection.Events.IceCandidateError, event);
     };
   }
 

--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -116,10 +116,8 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
       this.emit(PeerConnection.Events.IceCandidate, ev);
     };
 
-    this.pc.onicecandidateerror = (ev: Event) => {
-      const event = ev as RTCPeerConnectionIceErrorEvent;
-
-      this.emit(PeerConnection.Events.IceCandidateError, event);
+    this.pc.onicecandidateerror = (ev: RTCPeerConnectionIceErrorEvent) => {
+      this.emit(PeerConnection.Events.IceCandidateError, ev);
     };
   }
 


### PR DESCRIPTION
[SPARK-536950](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-536950)

This PR introduces forwarding of IceCandidateError event. We would like to be able to use it in JS-SDK to have a metrics about most common ice gathering issues.

With typescript update to version > 5.0, cast would not be needed.