### PR TITLE
fix: conditionally add device permissions

### DIFF
--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -14,6 +14,7 @@ import {
   createMicrophoneStream,
   getDevices,
 } from './device-management';
+import { WebrtcCoreError, WebrtcCoreErrorType } from '../errors';
 
 jest.mock('../mocks/media-stream-stub');
 
@@ -302,6 +303,20 @@ describe('Device Management', () => {
 
       const devices = await getDevices(media.DeviceKind.AudioInput);
       expect(devices).toStrictEqual([{ kind: 'audioinput', deviceId: 'audio1' }]);
+    });
+
+    it('should throw WebrtcCoreError when device permissions are denied', async () => {
+      expect.hasAssertions();
+      jest.spyOn(media, 'ensureDevicePermissions').mockImplementation(() => {
+        throw new Error();
+      });
+
+      const expectedError = new WebrtcCoreError(
+        WebrtcCoreErrorType.DEVICE_PERMISSION_DENIED,
+        'Failed to ensure device permissions'
+      );
+
+      await expect(getDevices()).rejects.toStrictEqual(expectedError);
     });
   });
 });

--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -12,6 +12,7 @@ import {
   createDisplayStream,
   createDisplayStreamWithAudio,
   createMicrophoneStream,
+  getDevices,
 } from './device-management';
 
 jest.mock('../mocks/media-stream-stub');
@@ -252,6 +253,55 @@ describe('Device Management', () => {
         'motion'
       );
       expect(localDisplayStream.contentHint).toBe('motion');
+    });
+  });
+
+  describe('getDevices', () => {
+    it('should call ensureDevicePermissions with both audio and video input kinds when no deviceKind is provided', async () => {
+      expect.hasAssertions();
+      const mockDevices = [
+        { kind: 'audioinput', deviceId: 'audio1' },
+        { kind: 'videoinput', deviceId: 'video1' },
+      ] as MediaDeviceInfo[];
+
+      jest.spyOn(media, 'ensureDevicePermissions').mockResolvedValue(mockDevices);
+      jest.spyOn(media, 'enumerateDevices').mockResolvedValue(mockDevices);
+
+      const devices = await getDevices();
+      expect(media.ensureDevicePermissions).toHaveBeenCalledWith(
+        [media.DeviceKind.AudioInput, media.DeviceKind.VideoInput],
+        media.enumerateDevices
+      );
+      expect(devices).toStrictEqual(mockDevices);
+    });
+
+    it('should call ensureDevicePermissions with the provided deviceKind', async () => {
+      expect.hasAssertions();
+      const mockDevices = [{ kind: 'audioinput', deviceId: 'audio1' }] as MediaDeviceInfo[];
+
+      jest.spyOn(media, 'ensureDevicePermissions').mockResolvedValue(mockDevices);
+      jest.spyOn(media, 'enumerateDevices').mockResolvedValue(mockDevices);
+
+      const devices = await getDevices(media.DeviceKind.AudioInput);
+      expect(media.ensureDevicePermissions).toHaveBeenCalledWith(
+        [media.DeviceKind.AudioInput],
+        media.enumerateDevices
+      );
+      expect(devices).toStrictEqual(mockDevices);
+    });
+
+    it('should filter devices based on the provided deviceKind', async () => {
+      expect.hasAssertions();
+      const mockDevices = [
+        { kind: 'audioinput', deviceId: 'audio1' },
+        { kind: 'videoinput', deviceId: 'video1' },
+      ] as MediaDeviceInfo[];
+
+      jest.spyOn(media, 'ensureDevicePermissions').mockResolvedValue(mockDevices);
+      jest.spyOn(media, 'enumerateDevices').mockResolvedValue(mockDevices);
+
+      const devices = await getDevices(media.DeviceKind.AudioInput);
+      expect(devices).toStrictEqual([{ kind: 'audioinput', deviceId: 'audio1' }]);
     });
   });
 });

--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -190,14 +190,9 @@ export async function createDisplayStreamWithAudio<
  */
 export async function getDevices(deviceKind?: media.DeviceKind): Promise<MediaDeviceInfo[]> {
   let devices: MediaDeviceInfo[];
-  const deviceKinds: media.DeviceKind[] = [];
-
-  // If deviceKind is provided, add it to the array. Otherwise, add both audio and video input kinds.
-  if (deviceKind !== undefined) {
-    deviceKinds.push(deviceKind);
-  } else {
-    deviceKinds.push(media.DeviceKind.AudioInput, media.DeviceKind.VideoInput);
-  }
+  const deviceKinds = deviceKind
+    ? [deviceKind]
+    : [media.DeviceKind.AudioInput, media.DeviceKind.VideoInput];
 
   try {
     devices = await media.ensureDevicePermissions(deviceKinds, media.enumerateDevices);

--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -190,11 +190,17 @@ export async function createDisplayStreamWithAudio<
  */
 export async function getDevices(deviceKind?: media.DeviceKind): Promise<MediaDeviceInfo[]> {
   let devices: MediaDeviceInfo[];
+  const deviceKinds: media.DeviceKind[] = [];
+
+  // If deviceKind is provided, add it to the array. Otherwise, add both audio and video input kinds.
+  if (deviceKind !== undefined) {
+    deviceKinds.push(deviceKind);
+  } else {
+    deviceKinds.push(media.DeviceKind.AudioInput, media.DeviceKind.VideoInput);
+  }
+
   try {
-    devices = await media.ensureDevicePermissions(
-      [media.DeviceKind.AudioInput, media.DeviceKind.VideoInput],
-      media.enumerateDevices
-    );
+    devices = await media.ensureDevicePermissions(deviceKinds, media.enumerateDevices);
   } catch (error) {
     throw new WebrtcCoreError(
       WebrtcCoreErrorType.DEVICE_PERMISSION_DENIED,


### PR DESCRIPTION
# Completes [SPARK-563488](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-563488)

This PR introduces improvements and additions to the device management functionality, including conditional device permissions and unit tests. `getDevices()` function checks for all permissions irrespective of what the user has passed as `deviceKind`. This can cause unnecessary permission prompts for devices that aren't needed by the user.

This can be tested with: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-539683