### PR TITLE
feat: add createDisplayMedia API

### DIFF
--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -176,7 +176,7 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream },
+        video: { displayStreamConstructor: LocalDisplayStream },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({ video: true, audio: false });
     });
@@ -185,8 +185,8 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream },
-        audio: { constructor: LocalSystemAudioStream },
+        video: { displayStreamConstructor: LocalDisplayStream },
+        audio: { systemAudioStreamConstructor: LocalSystemAudioStream },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({ video: true, audio: true });
     });
@@ -195,8 +195,11 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream, constraints: { frameRate: 5 } },
-        audio: { constructor: LocalSystemAudioStream, constraints: { autoGainControl: false } },
+        video: { displayStreamConstructor: LocalDisplayStream, constraints: { frameRate: 5 } },
+        audio: {
+          systemAudioStreamConstructor: LocalSystemAudioStream,
+          constraints: { autoGainControl: false },
+        },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({
         video: { frameRate: 5 },
@@ -208,7 +211,7 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       const [localDisplayStream] = await createDisplayMedia({
-        video: { constructor: LocalDisplayStream, videoContentHint: 'motion' },
+        video: { displayStreamConstructor: LocalDisplayStream, videoContentHint: 'motion' },
       });
       expect(localDisplayStream.contentHint).toBe('motion');
     });
@@ -217,7 +220,7 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream, preferCurrentTab: true },
+        video: { displayStreamConstructor: LocalDisplayStream, preferCurrentTab: true },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({
         video: true,
@@ -230,7 +233,7 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream, selfBrowserSurface: 'include' },
+        video: { displayStreamConstructor: LocalDisplayStream, selfBrowserSurface: 'include' },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({
         video: true,
@@ -243,7 +246,7 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream, surfaceSwitching: 'include' },
+        video: { displayStreamConstructor: LocalDisplayStream, surfaceSwitching: 'include' },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({
         video: true,
@@ -256,7 +259,7 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream, monitorTypeSurfaces: 'exclude' },
+        video: { displayStreamConstructor: LocalDisplayStream, monitorTypeSurfaces: 'exclude' },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({
         video: true,
@@ -269,8 +272,8 @@ describe('Device Management', () => {
       expect.assertions(1);
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream },
-        audio: { constructor: LocalSystemAudioStream, systemAudio: 'exclude' },
+        video: { displayStreamConstructor: LocalDisplayStream },
+        audio: { systemAudioStreamConstructor: LocalSystemAudioStream, systemAudio: 'exclude' },
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({
         video: true,
@@ -285,7 +288,7 @@ describe('Device Management', () => {
       const fakeController: CaptureController = {} as CaptureController;
 
       await createDisplayMedia({
-        video: { constructor: LocalDisplayStream },
+        video: { displayStreamConstructor: LocalDisplayStream },
         controller: fakeController,
       });
       expect(media.getDisplayMedia).toHaveBeenCalledWith({

--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -27,7 +27,7 @@ describe('Device Management', () => {
   const mockStream = createMockedStream();
 
   describe('createMicrophoneStream', () => {
-    jest.spyOn(media, 'getUserMedia').mockReturnValue(Promise.resolve(mockStream));
+    jest.spyOn(media, 'getUserMedia').mockResolvedValue(mockStream);
 
     it('should call getUserMedia', async () => {
       expect.assertions(1);
@@ -76,7 +76,7 @@ describe('Device Management', () => {
   });
 
   describe('createCameraStream', () => {
-    jest.spyOn(media, 'getUserMedia').mockReturnValue(Promise.resolve(mockStream));
+    jest.spyOn(media, 'getUserMedia').mockResolvedValue(mockStream);
 
     it('should call getUserMedia', async () => {
       expect.assertions(1);
@@ -123,7 +123,7 @@ describe('Device Management', () => {
   });
 
   describe('createCameraAndMicrophoneStreams', () => {
-    jest.spyOn(media, 'getUserMedia').mockReturnValue(Promise.resolve(mockStream));
+    jest.spyOn(media, 'getUserMedia').mockResolvedValue(mockStream);
 
     it('should call getUserMedia', async () => {
       expect.assertions(1);
@@ -170,7 +170,7 @@ describe('Device Management', () => {
   });
 
   describe('createDisplayMedia', () => {
-    jest.spyOn(media, 'getDisplayMedia').mockReturnValue(Promise.resolve(mockStream));
+    jest.spyOn(media, 'getDisplayMedia').mockResolvedValue(mockStream);
 
     it('should call getDisplayMedia with video only', async () => {
       expect.assertions(1);
@@ -300,7 +300,7 @@ describe('Device Management', () => {
   });
 
   describe('createDisplayStream', () => {
-    jest.spyOn(media, 'getDisplayMedia').mockReturnValue(Promise.resolve(mockStream));
+    jest.spyOn(media, 'getDisplayMedia').mockResolvedValue(mockStream);
 
     it('should call getDisplayMedia', async () => {
       expect.assertions(1);
@@ -325,7 +325,7 @@ describe('Device Management', () => {
   });
 
   describe('createDisplayStreamWithAudio', () => {
-    jest.spyOn(media, 'getDisplayMedia').mockReturnValue(Promise.resolve(mockStream));
+    jest.spyOn(media, 'getDisplayMedia').mockResolvedValue(mockStream);
 
     // This mock implementation is needed because createDisplayStreamWithAudio will create a new
     // MediaStream from the video track of the mocked stream, so we need to make sure this new
@@ -354,9 +354,7 @@ describe('Device Management', () => {
       expect.assertions(2);
 
       const mockStreamWithAudio = createMockedStreamWithAudio();
-      jest
-        .spyOn(media, 'getDisplayMedia')
-        .mockReturnValueOnce(Promise.resolve(mockStreamWithAudio));
+      jest.spyOn(media, 'getDisplayMedia').mockResolvedValueOnce(mockStreamWithAudio);
 
       const [localDisplayStream, localSystemAudioStream] = await createDisplayStreamWithAudio(
         LocalDisplayStream,

--- a/src/device/device-management.spec.ts
+++ b/src/device/device-management.spec.ts
@@ -1,5 +1,6 @@
 import { WebrtcCoreError, WebrtcCoreErrorType } from '../errors';
 import * as media from '../media';
+import { CaptureController } from '../media';
 import { LocalCameraStream } from '../media/local-camera-stream';
 import { LocalDisplayStream } from '../media/local-display-stream';
 import { LocalMicrophoneStream } from '../media/local-microphone-stream';
@@ -8,7 +9,6 @@ import { createBrowserMock } from '../mocks/create-browser-mock';
 import MediaStreamStub from '../mocks/media-stream-stub';
 import { createMockedStream, createMockedStreamWithAudio } from '../util/test-utils';
 import {
-  CaptureController,
   createCameraAndMicrophoneStreams,
   createCameraStream,
   createDisplayMedia,

--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -38,12 +38,12 @@ export interface CaptureController {
  * 1. Previous captured video stream from the same device is not stopped.
  * 2. Previous createCameraStream() call for the same device is in progress.
  *
- * @param constructor - Constructor for the local camera stream.
+ * @param cameraStreamConstructor - Constructor for the local camera stream.
  * @param constraints - Video device constraints.
  * @returns A LocalCameraStream object or an error.
  */
 export async function createCameraStream<T extends LocalCameraStream>(
-  constructor: Constructor<T>,
+  cameraStreamConstructor: Constructor<T>,
   constraints?: VideoDeviceConstraints
 ): Promise<T> {
   let stream: MediaStream;
@@ -55,18 +55,19 @@ export async function createCameraStream<T extends LocalCameraStream>(
       `Failed to create camera stream: ${error}`
     );
   }
-  return new constructor(stream);
+  // eslint-disable-next-line new-cap
+  return new cameraStreamConstructor(stream);
 }
 
 /**
  * Creates a LocalMicrophoneStream with the given constraints.
  *
- * @param constructor - Constructor for the local microphone stream.
+ * @param microphoneStreamConstructor - Constructor for the local microphone stream.
  * @param constraints - Audio device constraints.
  * @returns A LocalMicrophoneStream object or an error.
  */
 export async function createMicrophoneStream<T extends LocalMicrophoneStream>(
-  constructor: Constructor<T>,
+  microphoneStreamConstructor: Constructor<T>,
   constraints?: AudioDeviceConstraints
 ): Promise<T> {
   let stream: MediaStream;
@@ -78,7 +79,8 @@ export async function createMicrophoneStream<T extends LocalMicrophoneStream>(
       `Failed to create microphone stream: ${error}`
     );
   }
-  return new constructor(stream);
+  // eslint-disable-next-line new-cap
+  return new microphoneStreamConstructor(stream);
 }
 
 /**
@@ -130,7 +132,7 @@ export async function createCameraAndMicrophoneStreams<
  *
  * @param options - An object containing the options for creating the display and system audio streams.
  * @param options.video - An object containing the video stream options.
- * @param options.video.constructor - Constructor for the local display stream.
+ * @param options.video.displayStreamConstructor - Constructor for the local display stream.
  * @param options.video.constraints - Video device constraints.
  * @param options.video.videoContentHint - A hint for the content of the stream.
  * @param options.video.preferCurrentTab - Whether to offer the current tab as the most prominent capture source.
@@ -138,7 +140,7 @@ export async function createCameraAndMicrophoneStreams<
  * @param options.video.surfaceSwitching - Whether to allow the user to dynamically switch the shared tab during screen-sharing.
  * @param options.video.monitorTypeSurfaces - Whether to offer the user the option to choose display surfaces whose type is monitor.
  * @param options.audio - An object containing the audio stream options. If present, a system audio stream will be created.
- * @param options.audio.constructor - Constructor for the local system audio stream.
+ * @param options.audio.systemAudioStreamConstructor - Constructor for the local system audio stream.
  * @param options.audio.constraints - Audio device constraints.
  * @param options.audio.systemAudio - Whether to include the system audio among the possible audio sources offered to the user.
  * @param options.controller - CaptureController to further manipulate the capture session.
@@ -151,7 +153,7 @@ export async function createDisplayMedia<
   U extends LocalSystemAudioStream
 >(options: {
   video: {
-    constructor: Constructor<T>;
+    displayStreamConstructor: Constructor<T>;
     constraints?: VideoDeviceConstraints;
     videoContentHint?: VideoContentHint;
     preferCurrentTab?: boolean;
@@ -160,7 +162,7 @@ export async function createDisplayMedia<
     monitorTypeSurfaces?: 'include' | 'exclude';
   };
   audio?: {
-    constructor: Constructor<U>;
+    systemAudioStreamConstructor: Constructor<U>;
     constraints?: AudioDeviceConstraints;
     systemAudio?: 'include' | 'exclude';
   };
@@ -187,7 +189,7 @@ export async function createDisplayMedia<
     );
   }
   // eslint-disable-next-line new-cap
-  const localDisplayStream = new options.video.constructor(
+  const localDisplayStream = new options.video.displayStreamConstructor(
     new MediaStream(stream.getVideoTracks())
   );
   if (options.video.videoContentHint) {
@@ -196,7 +198,7 @@ export async function createDisplayMedia<
   let localSystemAudioStream = null;
   if (options.audio && stream.getAudioTracks().length > 0) {
     // eslint-disable-next-line new-cap
-    localSystemAudioStream = new options.audio.constructor(
+    localSystemAudioStream = new options.audio.systemAudioStreamConstructor(
       new MediaStream(stream.getAudioTracks())
     );
   }
@@ -206,16 +208,16 @@ export async function createDisplayMedia<
 /**
  * Creates a LocalDisplayStream with the given parameters.
  *
- * @param constructor - Constructor for the local display stream.
+ * @param displayStreamConstructor - Constructor for the local display stream.
  * @param videoContentHint - An optional parameter to give a hint for the content of the stream.
  * @returns A Promise that resolves to a LocalDisplayStream or an error.
  */
 export async function createDisplayStream<T extends LocalDisplayStream>(
-  constructor: Constructor<T>,
+  displayStreamConstructor: Constructor<T>,
   videoContentHint?: VideoContentHint
 ): Promise<T> {
   const [localDisplayStream] = await createDisplayMedia({
-    video: { constructor, videoContentHint },
+    video: { displayStreamConstructor, videoContentHint },
   });
   return localDisplayStream;
 }
@@ -239,8 +241,8 @@ export async function createDisplayStreamWithAudio<
   videoContentHint?: VideoContentHint
 ): Promise<[T, U | null]> {
   return createDisplayMedia({
-    video: { constructor: displayStreamConstructor, videoContentHint },
-    audio: { constructor: systemAudioStreamConstructor },
+    video: { displayStreamConstructor, videoContentHint },
+    audio: { systemAudioStreamConstructor },
   });
 }
 

--- a/src/device/device-management.ts
+++ b/src/device/device-management.ts
@@ -1,5 +1,6 @@
 import { WebrtcCoreError, WebrtcCoreErrorType } from '../errors';
 import * as media from '../media';
+import { CaptureController } from '../media';
 import { LocalCameraStream } from '../media/local-camera-stream';
 import { LocalDisplayStream } from '../media/local-display-stream';
 import { LocalMicrophoneStream } from '../media/local-microphone-stream';
@@ -24,13 +25,6 @@ export type VideoDeviceConstraints = Pick<
   MediaTrackConstraints,
   'aspectRatio' | 'deviceId' | 'facingMode' | 'frameRate' | 'height' | 'width'
 >;
-
-// CaptureController is experimental so TypeScript doesn't have a type for it yet.
-// So we define the interface ourselves here.
-// See https://developer.mozilla.org/en-US/docs/Web/API/CaptureController.
-export interface CaptureController {
-  setFocusBehavior(behavior: 'auto' | 'always' | 'never'): Promise<void>;
-}
 
 /**
  * Creates a camera stream. Please note that the constraint params in second getUserMedia call would NOT take effect when:
@@ -181,7 +175,7 @@ export async function createDisplayMedia<
       surfaceSwitching: options.video.surfaceSwitching,
       systemAudio: options.audio?.systemAudio,
       monitorTypeSurfaces: options.video.monitorTypeSurfaces,
-    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    });
   } catch (error) {
     throw new WebrtcCoreError(
       WebrtcCoreErrorType.CREATE_STREAM_FAILED,

--- a/src/media/index.ts
+++ b/src/media/index.ts
@@ -6,6 +6,15 @@ export enum DeviceKind {
   VideoInput = 'videoinput',
 }
 
+// CaptureController is experimental so TypeScript doesn't have a type for it yet.
+// So we define the interface ourselves here.
+// See https://developer.mozilla.org/en-US/docs/Web/API/CaptureController.
+export interface CaptureController {
+  setFocusBehavior(
+    behavior: 'focus-capturing-application' | 'focus-captured-surface' | 'no-focus-change'
+  ): Promise<void>;
+}
+
 /**
  * Prompts the user for permission to use a media input which produces a MediaStream with tracks
  * containing the requested types of media.
@@ -21,14 +30,23 @@ export async function getUserMedia(constraints: MediaStreamConstraints): Promise
 
 /**
  * Prompts the user for permission to use a user's display media and audio. If a video track is
- * absent from the constraints argument, one will still be provided.
+ * absent from the constraints argument, one will still be provided. Includes experimental options
+ * found in https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia#options.
  *
  * @param constraints - A MediaStreamConstraints object specifying the types of media to request,
- *     along with any requirements for each type.
+ *     along with any requirements for each type, as well as experimental options.
  * @returns A Promise whose fulfillment handler receives a MediaStream object when the requested
  *     media has successfully been obtained.
  */
-export function getDisplayMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
+export function getDisplayMedia(
+  constraints: MediaStreamConstraints & {
+    controller?: CaptureController;
+    selfBrowserSurface?: 'include' | 'exclude';
+    surfaceSwitching?: 'include' | 'exclude';
+    systemAudio?: 'include' | 'exclude';
+    monitorTypeSurfaces?: 'include' | 'exclude';
+  }
+): Promise<MediaStream> {
   return navigator.mediaDevices.getDisplayMedia(constraints);
 }
 


### PR DESCRIPTION
This PR adds a new `createDisplayMedia` API that calls `getDisplayMedia` with additional options not currently possible with the existing `createDisplayStream` and `createDisplayStreamWithAudio` APIs, as part of [SPARK-610118](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-610118). In particular, they add the following options:

- Video and audio device constraints.
- Ability to specify whether to offer the current tab as the most prominent capture source.
- Ability to specify whether to allow the user to select the current tab for capture.
- Ability to specify whether to allow the user to dynamically switch the shared tab during screen-sharing.
- Ability to specify whether to offer the user the option to choose display surfaces whose type is monitor.
- Ability to specify whether to include the system audio among the possible audio sources offered to the user.
- CaptureController to further manipulate the capture session.

I've also cleaned up some of the unit tests to remove some logic that I don't believe are necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced display media capture functionality with more granular configuration options.
	- Added support for simultaneous video and system audio stream creation.
	- Introduced `CaptureController` for advanced media capture session management.

- **Improvements**
	- Refined media stream creation methods with clearer parameter naming.
	- Improved backward compatibility for existing media stream methods.
	- Expanded test coverage for media stream functionalities, ensuring robust validation of behavior under various configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->