### PR TITLE
feat: add getIceCandidates functionality

### DIFF
--- a/src/mocks/rtc-peer-connection-stub.ts
+++ b/src/mocks/rtc-peer-connection-stub.ts
@@ -29,6 +29,7 @@ class RTCPeerConnectionStub {
   }
   onconnectionstatechange: () => void = () => {};
   oniceconnectionstatechange: () => void = () => {};
+  onicecandidate: (event: RTCPeerConnectionIceEvent) => void = () => {};
 }
 
 /**

--- a/src/peer-connection.spec.ts
+++ b/src/peer-connection.spec.ts
@@ -264,6 +264,68 @@ describe('PeerConnection', () => {
       connectionStateHandlerListener('checking');
     });
   });
+
+  describe('getIceCandidates', () => {
+    let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
+    let pc: PeerConnection;
+
+    beforeEach(() => {
+      mockPc = mocked(new RTCPeerConnectionStub(), true);
+
+      mockCreateRTCPeerConnection.mockReturnValueOnce(mockPc as unknown as RTCPeerConnection);
+
+      pc = new PeerConnection();
+    });
+
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    const emitIceCandidate = (iceCandidate: RTCIceCandidate | null) => {
+      mockPc.onicecandidate({
+        candidate: iceCandidate,
+      } as RTCPeerConnectionIceEvent);
+    };
+
+    it('should return empty array if no ice candidates were gathered', () => {
+      expect.hasAssertions();
+
+      const iceCandidates = pc.getIceCandidates();
+
+      expect(iceCandidates).toBeDefined();
+      expect(iceCandidates).toHaveLength(0);
+    });
+
+    it('should store ice candidates', () => {
+      expect.hasAssertions();
+
+      emitIceCandidate({ address: '1.2.3.4', port: 1234 } as RTCIceCandidate);
+
+      emitIceCandidate({ address: '2.3.4.5', port: 2345 } as RTCIceCandidate);
+
+      const iceCandidates = pc.getIceCandidates();
+
+      expect(iceCandidates).toBeDefined();
+      expect(iceCandidates).toHaveLength(2);
+      expect(iceCandidates[0]).toStrictEqual({
+        address: '1.2.3.4',
+        port: 1234,
+      });
+      expect(iceCandidates[1]).toStrictEqual({
+        address: '2.3.4.5',
+        port: 2345,
+      });
+    });
+
+    it('should not store null ice candidate', () => {
+      expect.hasAssertions();
+
+      emitIceCandidate(null);
+
+      const iceCandidates = pc.getIceCandidates();
+
+      expect(iceCandidates).toBeDefined();
+      expect(iceCandidates).toHaveLength(0);
+    });
+  });
+
   describe('createAnswer', () => {
     let mockPc: MockedObjectDeep<RTCPeerConnectionStub>;
     let createAnswerSpy: jest.SpyInstance;

--- a/src/peer-connection.ts
+++ b/src/peer-connection.ts
@@ -64,6 +64,8 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
 
   private connectionStateHandler: ConnectionStateHandler;
 
+  private iceCandidates: RTCIceCandidate[] = [];
+
   /**
    * Creates an instance of the RTCPeerConnection.
    *
@@ -113,6 +115,10 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
 
     /* eslint-disable jsdoc/require-jsdoc */
     this.pc.onicecandidate = (ev: RTCPeerConnectionIceEvent) => {
+      if (ev.candidate) {
+        this.iceCandidates.push(ev.candidate);
+      }
+
       this.emit(PeerConnection.Events.IceCandidate, ev);
     };
 
@@ -155,6 +161,15 @@ class PeerConnection extends EventEmitter<PeerConnectionEventHandlers> {
    */
   getIceConnectionState(): RTCIceConnectionState {
     return this.connectionStateHandler.getIceConnectionState();
+  }
+
+  /**
+   * Gets the list of ICE candidates that have been gathered.
+   *
+   * @returns An array of RTCIceCandidate objects representing the ICE candidates.
+   */
+  getIceCandidates(): RTCIceCandidate[] {
+    return this.iceCandidates;
   }
 
   /**


### PR DESCRIPTION
[SPARK-669676](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-669676)

This PR adds a possibility to access gathered ICE Candidates which will be stored inside of the PeerConnection class.

This change will make accessing already gathered candidates more convenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a method to view all collected ICE candidates in peer connections.

- **Tests**
  - Introduced new tests to verify the correct collection and retrieval of ICE candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->